### PR TITLE
Issue 3 - Use SHA1 for assets location/path

### DIFF
--- a/express/app/utils/build.js
+++ b/express/app/utils/build.js
@@ -16,7 +16,7 @@ const getBuildId = req => {
 
 const getAssetsPath = (relativePath, sha) => {
   const ext = relativePath.split('.').slice(-1)[0];
-  return `${relativePath}/${sha}.${ext}`;
+  return `${sha}.${ext}`;
 };
 
 const getProject = async req => {

--- a/express/tests/unit/utils/build.test.js
+++ b/express/tests/unit/utils/build.test.js
@@ -120,6 +120,6 @@ describe('build utils', () => {
   });
   test('getAssetsPath', () => {
     const path = utils.getAssetsPath('path/to/test.json', '1234eacd');
-    expect(path).toBe('path/to/test.json/1234eacd.json');
+    expect(path).toBe('1234eacd.json');
   });
 });


### PR DESCRIPTION
fixes #3 

- use SHA1 and file extension as path
- this solves issues with:
  - duplicate files with different paths
  - existing assets with different paths for future builds