### PR TITLE
Issue 4 - fix basset-worker issues

### DIFF
--- a/express/app/tasks/builds.js
+++ b/express/app/tasks/builds.js
@@ -1,6 +1,6 @@
 const Build = require('../models/Build');
 
-const buildTimeout = 10 * 60 * 1000; // 10 minutes
+const buildTimeout = 20 * 60 * 1000; // 20 minutes
 
 const monitorBuildStatus = async ({ buildId }) => {
   const build = await Build.query().findById(buildId);
@@ -26,8 +26,7 @@ const monitorBuildStatus = async ({ buildId }) => {
     return;
   }
   setTimeout(async () => {
-    await monitorBuildStatus(buildId);
-    console.log('ran it baby', buildId)
+    await monitorBuildStatus({ buildId });
   }, 60 * 1000); // 60 seconds
 };
 

--- a/express/app/tasks/workers.js
+++ b/express/app/tasks/workers.js
@@ -8,7 +8,8 @@ const run = () => {
   if (settings.sqs.use) {
     const aws = require('aws-sdk');
     const sqs = new aws.SQS({ apiVersion: '2012-11-05' });
-    setImmediate(() => {
+    setInterval(() => {
+      console.log('checking for new messages');
       sqs.receiveMessage(
         {
           QueueUrl: settings.sqs.taskUrl,
@@ -23,11 +24,10 @@ const processSQSMessages = async (err, data) => {
   if (err) {
     console.error('Error retrieving messages', err);
   }
-  const aws = require('aws-sdk');
-  const sqs = new aws.SQS({ apiVersion: '2012-11-05' });
   if (data.Messages) {
+    const aws = require('aws-sdk');
+    const sqs = new aws.SQS({ apiVersion: '2012-11-05' });
     for await (message of data.Messages) {
-      console.log(`received message`);
       await processMessage(JSON.parse(message.Body));
       const deleteParams = {
         QueueUrl: settings.sqs.taskUrl,

--- a/express/tests/unit/models/Build.test.js
+++ b/express/tests/unit/models/Build.test.js
@@ -51,7 +51,7 @@ describe('Build', () => {
 
     otherUser = await createUser('snapshot@snapshotmodel2.io');
     otherOrganization = await createOrganization('snapshotmodel2');
-    addUserToOrganization(otherOrganization.id, otherUser.id, true);
+    await addUserToOrganization(otherOrganization.id, otherUser.id, true);
     otherUser = await otherUser.$query().eager('organizations');
 
     project = await createProject('test', organization.id, {

--- a/express/tests/unit/tasks/builds.test.js
+++ b/express/tests/unit/tasks/builds.test.js
@@ -10,11 +10,11 @@ describe('build tasks', () => {
     organization = await createOrganization('builder');
     project = await createProject('tester', organization.id);
   });
-  test('monitorBuildStats error when 10 minutes have passed with 0 snapshots', async () => {
+  test('monitorBuildStats error when 20 minutes have passed with 0 snapshots', async () => {
     jest.useFakeTimers();
     let build = await createBuild('master', project);
     const date = new Date();
-    date.setMinutes(date.getMinutes() - 11);
+    date.setMinutes(date.getMinutes() - 21);
     build.__proto__.$beforeUpdate = () => {};
     await build.$query().update({
       updatedAt: date.toISOString(),
@@ -24,12 +24,12 @@ describe('build tasks', () => {
     expect(build.error).toBe(true);
   });
 
-  test('monitorBuildStats error when last snapshot is greater than 10 minutes from build updatedAt', async () => {
+  test('monitorBuildStats error when last snapshot is greater than 20 minutes from build updatedAt', async () => {
     jest.useFakeTimers();
     let build = await createBuild('master', project);
     await createSnapshot('test', build);
     const date = new Date();
-    date.setMinutes(date.getMinutes() - 11);
+    date.setMinutes(date.getMinutes() - 21);
     build.__proto__.$beforeUpdate = () => {};
     await build.$query().update({
       updatedAt: date.toISOString(),
@@ -54,7 +54,7 @@ describe('build tasks', () => {
     });
     jest.advanceTimersByTime(60000);
     const date = new Date();
-    date.setMinutes(date.getMinutes() - 11);
+    date.setMinutes(date.getMinutes() - 21);
     build.__proto__.$beforeUpdate = () => {};
     await build.$query().update({
       updatedAt: date.toISOString(),


### PR DESCRIPTION
- increases the timeout to 20 minutes
- uses `setInterval`
- fixes the call params for `monitorBuildStatus`
- fixes a flakey test