### PR TITLE
Issue 5 - Fix issue loading more snapshots in group

### DIFF
--- a/express/app/schema/snapshot.js
+++ b/express/app/schema/snapshot.js
@@ -245,9 +245,8 @@ const resolvers = {
       return {
         totalCount: pageQuery
           .clone()
-          .countDistinct('group')
-          .first()
-          .then(r => parseInt(r.count) + 1),
+          .distinct('group')
+          .then(r => r.length),
         edges: pageQuery
           .clone()
           .distinct('group')

--- a/react/src/app/snapshots/components/SnapshotGroups.jsx
+++ b/react/src/app/snapshots/components/SnapshotGroups.jsx
@@ -138,7 +138,7 @@ class SnapshotGroups extends React.PureComponent {
                     <LoadMoreButton
                       isLoadingMore={!!this.props.isLoadingMoreFromGroup[group]}
                       onLoadMore={() => this.props.onLoadMoreFromGroup(group)}
-                      label="Load more from group"
+                      label={group.group === null ? 'Load more' : 'Load more similar snapshots'}
                     />
                   </Box>
                 )}

--- a/react/src/graphql/fragments/snapshot.js
+++ b/react/src/graphql/fragments/snapshot.js
@@ -1,0 +1,44 @@
+export default `
+fragment snapshotFragment on Snapshot {
+  id
+  imageLocation
+  approved
+  approvedOn
+  title
+  width
+  browser
+  diff
+  approvedBy {
+    user {
+      id
+      name
+    }
+  }
+  previousApproved {
+    id
+    imageLocation
+    approved
+    approvedOn
+    approvedBy {
+      user {
+        id
+        name
+      }
+    }
+  }
+  snapshotDiff {
+    snapshotFromId
+    snapshotToId
+    imageLocation
+  }
+  snapshotFlake {
+    imageLocation
+    ignoredCount
+    createdBy {
+      user {
+        id
+        name
+      }
+    }
+  }
+}`;

--- a/react/src/graphql/query/getSnapshot.js
+++ b/react/src/graphql/query/getSnapshot.js
@@ -1,42 +1,11 @@
 import gql from 'graphql-tag';
+import snapshotFragment from '../fragments/snapshot.js';
 
 export default gql`
+  ${snapshotFragment}
   query snapshot($id: ID!) {
     snapshot(id: $id) {
-      id
-      buildId
-      projectId
-      organizationId
-      imageLocation
-      approved
-      approvedOn
-      title
-      width
-      browser
-      diff
-      approvedBy {
-        user {
-          id
-          name
-        }
-      }
-      previousApproved {
-        id
-        imageLocation
-        approved
-        approvedOn
-        approvedBy {
-          user {
-            id
-            name
-          }
-        }
-      }
-      snapshotDiff {
-        snapshotFromId
-        snapshotToId
-        imageLocation
-      }
+      ...snapshotFragment
     }
   }
 `;

--- a/react/src/graphql/query/getSnapshotGroups.js
+++ b/react/src/graphql/query/getSnapshotGroups.js
@@ -1,6 +1,8 @@
 import gql from 'graphql-tag';
+import snapshotFragment from '../fragments/snapshot.js';
 
 export default gql`
+  ${snapshotFragment}
   query modifiedSnapshotGroups($buildId: ID!, $limit: Int!, $offset: Int!, $first: Int!) {
     modifiedSnapshotGroups(buildId: $buildId, limit: $limit, offset: $offset) {
       totalCount
@@ -16,47 +18,7 @@ export default gql`
             edges {
               cursor
               node {
-                id
-                imageLocation
-                approved
-                approvedOn
-                title
-                width
-                browser
-                diff
-                approvedBy {
-                  user {
-                    id
-                    name
-                  }
-                }
-                previousApproved {
-                  id
-                  imageLocation
-                  approved
-                  approvedOn
-                  approvedBy {
-                    user {
-                      id
-                      name
-                    }
-                  }
-                }
-                snapshotDiff {
-                  snapshotFromId
-                  snapshotToId
-                  imageLocation
-                }
-                snapshotFlake {
-                  imageLocation
-                  ignoredCount
-                  createdBy {
-                    user {
-                      id
-                      name
-                    }
-                  }
-                }
+                ...snapshotFragment
               }
             }
           }

--- a/react/src/graphql/query/getSnapshots.js
+++ b/react/src/graphql/query/getSnapshots.js
@@ -1,6 +1,8 @@
 import gql from 'graphql-tag';
+import snapshotFragment from '../fragments/snapshot.js';
 
 export default gql`
+  ${snapshotFragment}
   query snapshots(
     $buildId: ID!
     $first: Int!
@@ -22,37 +24,7 @@ export default gql`
       edges {
         cursor
         node {
-          id
-          imageLocation
-          approved
-          approvedOn
-          title
-          width
-          browser
-          diff
-          approvedBy {
-            user {
-              id
-              name
-            }
-          }
-          previousApproved {
-            id
-            imageLocation
-            approved
-            approvedOn
-            approvedBy {
-              user {
-                id
-                name
-              }
-            }
-          }
-          snapshotDiff {
-            snapshotFromId
-            snapshotToId
-            imageLocation
-          }
+          ...snapshotFragment
         }
       }
     }

--- a/react/src/graphql/query/getSnapshotsFromGroup.js
+++ b/react/src/graphql/query/getSnapshotsFromGroup.js
@@ -1,6 +1,8 @@
 import gql from 'graphql-tag';
+import snapshotFragment from '../fragments/snapshot.js';
 
 export default gql`
+  ${snapshotFragment}
   query modifiedSnapshotGroups($buildId: ID!, $group: Int, $first: Int, $after: String) {
     modifiedSnapshots(buildId: $buildId, first: $first, after: $after, group: $group) {
       pageInfo {
@@ -9,37 +11,7 @@ export default gql`
       edges {
         cursor
         node {
-          id
-          imageLocation
-          approved
-          approvedOn
-          title
-          width
-          browser
-          diff
-          approvedBy {
-            user {
-              id
-              name
-            }
-          }
-          previousApproved {
-            id
-            imageLocation
-            approved
-            approvedOn
-            approvedBy {
-              user {
-                id
-                name
-              }
-            }
-          }
-          snapshotDiff {
-            snapshotFromId
-            snapshotToId
-            imageLocation
-          }
+          ...snapshotFragment
         }
       }
     }


### PR DESCRIPTION
Fixes #5 
- use fragment for snapshot queries
- update text of load more for grouped snapshots. Null group reads `load more` while other groups will read `load more similar snapshots`
- fix an issue when all snapshots are grouped `totalCount` was + 1. Previously count distinct was used which excludes null values so +1 as always added, but if there is no null snapshot group the `totalCount `was incorrect.