### PR TITLE
Builds - check for projectId when querying for previousBuild

### DIFF
--- a/express/app/models/Build.js
+++ b/express/app/models/Build.js
@@ -128,11 +128,11 @@ class Build extends BaseModel {
           url: pullRequestUrl,
           token: project.repoToken,
         });
-        //baseBranch = pullRequestData.base.ref;
         baseSHA = pullRequestData.base.sha;
       }
     }
     const baseQuery = Build.query()
+      .where('projectId', this.projectId)
       .where('buildVerified', true)
       .whereNotNull('completedAt')
       .orderBy('completedAt', 'desc')

--- a/express/tests/unit/models/Build.test.js
+++ b/express/tests/unit/models/Build.test.js
@@ -206,8 +206,8 @@ describe('Build', () => {
       expect(await newBuild.getPreviousBuild(project)).toEqual(baseBuild);
     });
 
-    it('should only return previous build for the project', async () => {
-      const newBuild = await createBuild('diffBranch', project2);
+    it('should return undefined if no previous build is found', async () => {
+      const newBuild = await createBuild('diffBranch', otherProject);
       const previousBuild = await newBuild.getPreviousBuild();
       expect(previousBuild).toBeUndefined();
     });

--- a/express/tests/unit/models/Build.test.js
+++ b/express/tests/unit/models/Build.test.js
@@ -205,6 +205,12 @@ describe('Build', () => {
       const newBuild = await createBuild('diffBranch', project);
       expect(await newBuild.getPreviousBuild(project)).toEqual(baseBuild);
     });
+
+    it('should only return previous build for the project', async () => {
+      const newBuild = await createBuild('diffBranch', project2);
+      const previousBuild = await newBuild.getPreviousBuild();
+      expect(previousBuild).toBeUndefined();
+    });
   });
 
   test('compareSnapshots', async () => {


### PR DESCRIPTION
- fixes #12
- check for projectId when querying for a previousBuild 