### PR TITLE
Issue-20 - Properly check remaining modified snapshots

### DIFF
--- a/express/app/schema/build.js
+++ b/express/app/schema/build.js
@@ -83,7 +83,7 @@ const loadBuilds = async items => {
       .as('approvedSnapshots'),
     Build.relatedQuery('snapshots')
       .where('flake', true)
-      .whereNotNull('snapshotFlakeMatched')
+      .whereNotNull('snapshotFlakeMatchedId')
       .count()
       .as('flakedSnapshots'),
     Build.relatedQuery('snapshots')

--- a/express/tests/unit/schema/snapshot.test.js
+++ b/express/tests/unit/schema/snapshot.test.js
@@ -403,7 +403,7 @@ describe('snapshot schema', () => {
           result.errors.some(
             e =>
               e.message ===
-              'This snapshot has already been set as a flake, you cannot approve it.',
+              'This snapshot has already been approved or does not require approving.',
           ),
         ).toBe(true);
       });

--- a/express/tests/unit/schema/snapshot.test.js
+++ b/express/tests/unit/schema/snapshot.test.js
@@ -16,7 +16,6 @@ jest.mock('../../../app/utils/upload', () => ({
 
 const upload = require('../../../app/utils/upload');
 
-
 describe('snapshot schema', () => {
   let user, otherUser;
   let organization, otherOrganization;
@@ -144,28 +143,79 @@ describe('snapshot schema', () => {
       ];
       const newBuild = await createBuild('test', project);
       const newSnapshots = [
-        await createSnapshot('test 1', newBuild, { diff: true, previousApprovedId: oldSnapshots[0].id }),
-        await createSnapshot('test 2', newBuild, { diff: true, previousApprovedId: oldSnapshots[1].id }),
-        await createSnapshot('test 3', newBuild, { diff: true, previousApprovedId: oldSnapshots[2].id }),
-        await createSnapshot('test 4', newBuild, { diff: true, previousApprovedId: oldSnapshots[3].id }),
-        await createSnapshot('test 5', newBuild, { diff: true, previousApprovedId: oldSnapshots[4].id }),
-        await createSnapshot('test 6', newBuild, { diff: true, previousApprovedId: oldSnapshots[5].id }),
-        await createSnapshot('test 7', newBuild, { approved: true, diff: true, previousApprovedId: oldSnapshots[6].id }),
-        await createSnapshot('test 8', newBuild, { diff: true, previousApprovedId: oldSnapshots[7].id }),
-        await createSnapshot('test 9', newBuild, { diff: true, previousApprovedId: oldSnapshots[8].id }),
-        await createSnapshot('test 10', newBuild, { diff: true, previousApprovedId: oldSnapshots[9].id }),
+        await createSnapshot('test 1', newBuild, {
+          diff: true,
+          previousApprovedId: oldSnapshots[0].id,
+        }),
+        await createSnapshot('test 2', newBuild, {
+          diff: true,
+          previousApprovedId: oldSnapshots[1].id,
+        }),
+        await createSnapshot('test 3', newBuild, {
+          diff: true,
+          previousApprovedId: oldSnapshots[2].id,
+        }),
+        await createSnapshot('test 4', newBuild, {
+          diff: true,
+          previousApprovedId: oldSnapshots[3].id,
+        }),
+        await createSnapshot('test 5', newBuild, {
+          diff: true,
+          previousApprovedId: oldSnapshots[4].id,
+        }),
+        await createSnapshot('test 6', newBuild, {
+          diff: true,
+          previousApprovedId: oldSnapshots[5].id,
+        }),
+        await createSnapshot('test 7', newBuild, {
+          approved: true,
+          diff: true,
+          previousApprovedId: oldSnapshots[6].id,
+        }),
+        await createSnapshot('test 8', newBuild, {
+          diff: true,
+          previousApprovedId: oldSnapshots[7].id,
+        }),
+        await createSnapshot('test 9', newBuild, {
+          diff: true,
+          previousApprovedId: oldSnapshots[8].id,
+        }),
+        await createSnapshot('test 10', newBuild, {
+          diff: true,
+          previousApprovedId: oldSnapshots[9].id,
+        }),
       ];
       const snapshotDiffs = [
-        await createSnapshotDiff(oldSnapshots[0], newSnapshots[0], newBuild, { group: 1 }),
-        await createSnapshotDiff(oldSnapshots[1], newSnapshots[1], newBuild, { group: 1 }),
-        await createSnapshotDiff(oldSnapshots[2], newSnapshots[2], newBuild, { group: 3 }),
-        await createSnapshotDiff(oldSnapshots[3], newSnapshots[3], newBuild, { group: 3 }),
-        await createSnapshotDiff(oldSnapshots[4], newSnapshots[4], newBuild, { group: 2 }),
-        await createSnapshotDiff(oldSnapshots[5], newSnapshots[5], newBuild, { group: 2 }),
-        await createSnapshotDiff(oldSnapshots[6], newSnapshots[6], newBuild, { group: 2 }),
-        await createSnapshotDiff(oldSnapshots[7], newSnapshots[7], newBuild, { group: null }),
-        await createSnapshotDiff(oldSnapshots[8], newSnapshots[8], newBuild, { group: null }),
-        await createSnapshotDiff(oldSnapshots[9], newSnapshots[9], newBuild, { group: null }),
+        await createSnapshotDiff(oldSnapshots[0], newSnapshots[0], newBuild, {
+          group: 1,
+        }),
+        await createSnapshotDiff(oldSnapshots[1], newSnapshots[1], newBuild, {
+          group: 1,
+        }),
+        await createSnapshotDiff(oldSnapshots[2], newSnapshots[2], newBuild, {
+          group: 3,
+        }),
+        await createSnapshotDiff(oldSnapshots[3], newSnapshots[3], newBuild, {
+          group: 3,
+        }),
+        await createSnapshotDiff(oldSnapshots[4], newSnapshots[4], newBuild, {
+          group: 2,
+        }),
+        await createSnapshotDiff(oldSnapshots[5], newSnapshots[5], newBuild, {
+          group: 2,
+        }),
+        await createSnapshotDiff(oldSnapshots[6], newSnapshots[6], newBuild, {
+          group: 2,
+        }),
+        await createSnapshotDiff(oldSnapshots[7], newSnapshots[7], newBuild, {
+          group: null,
+        }),
+        await createSnapshotDiff(oldSnapshots[8], newSnapshots[8], newBuild, {
+          group: null,
+        }),
+        await createSnapshotDiff(oldSnapshots[9], newSnapshots[9], newBuild, {
+          group: null,
+        }),
       ];
       const query = `
       query modifiedSnapshotGroups($first: Int, $after: String, $buildId: ID!, $limit: Int!, $offset: Int!) {
@@ -245,7 +295,10 @@ describe('snapshot schema', () => {
   describe('mutation', () => {
     describe('addSnapshotFlake', () => {
       test('can create snapshot flake', async () => {
-        const newSnapshot = await createSnapshot('test 1', build, { diff: true, previousApprovedId: snapshot.id });
+        const newSnapshot = await createSnapshot('test 1', build, {
+          diff: true,
+          previousApprovedId: snapshot.id,
+        });
         await createSnapshotDiff(snapshot, newSnapshot, build, { group: 1 });
         const query = `
         mutation addSnapshotFlake($id: ID!) {
@@ -259,15 +312,17 @@ describe('snapshot schema', () => {
             }
           }
         }
-      `;
-      const variables = {
-        id: newSnapshot.id,
-      };
-      const result = await runQuery(query, user, variables);
-      expect(result.data.addSnapshotFlake.imageLocation).toBe('imageLocation');
-      expect(result.data.addSnapshotFlake.createdBy.user.id).toBe(user.id);
-      expect(upload.copySnapshotDiffToFlake).toHaveBeenCalled();
-      })
+        `;
+        const variables = {
+          id: newSnapshot.id,
+        };
+        const result = await runQuery(query, user, variables);
+        expect(result.data.addSnapshotFlake.imageLocation).toBe(
+          'imageLocation',
+        );
+        expect(result.data.addSnapshotFlake.createdBy.user.id).toBe(user.id);
+        expect(upload.copySnapshotDiffToFlake).toHaveBeenCalled();
+      });
     });
 
     describe('approveSnapshot', () => {
@@ -293,6 +348,64 @@ describe('snapshot schema', () => {
         expect(result.data.approveSnapshot.approved).toBe(true);
         expect(result.data.approveSnapshot.approvedBy.user.id).toBe(user.id);
         expect(result.data.approveSnapshot.approvedOn).toBeDefined();
+      });
+      test('approving last snapshot verifies the build', async () => {
+        const query = `
+          mutation approveSnapshot($id: ID!) {
+            approveSnapshot(id: $id) {
+              id
+            }
+          }
+        `;
+        let newBuild = await createBuild('tester', project);
+        const newSnapshot = await createSnapshot('test', newBuild, {
+          diff: true,
+        });
+        const variables = {
+          id: newSnapshot.id,
+        };
+        await runQuery(query, user, variables);
+        newBuild = await newBuild.$query();
+        expect(newBuild.buildVerified).toBe(true);
+      });
+      test('cannot approve snapshot that has been set as a flake', async () => {
+        const newSnapshot = await createSnapshot('test 1', build, {
+          diff: true,
+          previousApprovedId: snapshot.id,
+        });
+        await createSnapshotDiff(snapshot, newSnapshot, build, { group: 1 });
+        const flakeQuery = `
+        mutation addSnapshotFlake($id: ID!) {
+          addSnapshotFlake(id: $id) {
+            id
+            imageLocation
+            createdBy {
+              user {
+                id
+              }
+            }
+          }
+        }
+        `;
+        const variables = {
+          id: newSnapshot.id,
+        };
+        await runQuery(flakeQuery, user, variables);
+        const query = `
+          mutation approveSnapshot($id: ID!) {
+            approveSnapshot(id: $id) {
+              id
+            }
+          }
+        `;
+        const result = await runQuery(query, user, variables);
+        expect(
+          result.errors.some(
+            e =>
+              e.message ===
+              'This snapshot has already been set as a flake, you cannot approve it.',
+          ),
+        ).toBe(true);
       });
     });
 
@@ -330,6 +443,48 @@ describe('snapshot schema', () => {
         expect(approvedSnapshots[0].approvedBy.user.id).toBe(user.id);
         expect(approvedSnapshots[0].approvedOn).toBeDefined();
       });
+
+      test('does not approve snapshots that have been set as a flake', async () => {
+        const oldBuild = await createBuild('oldBuild', project);
+        const oldSnapshot = await createSnapshot('old snapshot', oldBuild);
+        const newBuild = await createBuild('newBuild', project);
+        const newSnapshot = await createSnapshot('test 1', newBuild, {
+          diff: true,
+          previousApprovedId: oldSnapshot.id,
+        });
+        await createSnapshotDiff(oldSnapshot, newSnapshot, newBuild, { group: 1 });
+        const flakeQuery = `
+        mutation addSnapshotFlake($id: ID!) {
+          addSnapshotFlake(id: $id) {
+            id
+            imageLocation
+            createdBy {
+              user {
+                id
+              }
+            }
+          }
+        }
+        `;
+        let variables = {
+          id: newSnapshot.id,
+        };
+        await runQuery(flakeQuery, user, variables);
+        variables = {
+          buildId: newBuild.id,
+          group: 1,
+        };
+        await runQuery(query, user, variables);
+        const approvedSnapshots = await Snapshots.query()
+          .joinRelation('snapshotDiff')
+          .where('snapshot.buildId', newBuild.id)
+          .where('snapshotDiff.group', 1)
+          .where('approved', true)
+          .eager('approvedBy.user');
+        expect(approvedSnapshots).toHaveLength(0);
+        const totalSnapshots = await newBuild.$relatedQuery('snapshots');
+        expect(totalSnapshots).toHaveLength(1);
+      })
     });
 
     describe('approveGroupSnapshots', () => {
@@ -342,7 +497,11 @@ describe('snapshot schema', () => {
         `;
       });
       test('can approve snapshots already approved', async () => {
-        const newSnapshot = await createSnapshot('test 1', build, { diff: true, approved: true, previousApprovedId: snapshot.id });
+        const newSnapshot = await createSnapshot('test 1', build, {
+          diff: true,
+          approved: true,
+          previousApprovedId: snapshot.id,
+        });
         await createSnapshotDiff(snapshot, newSnapshot, build, { group: 1 });
         const variables = {
           buildId: build.id,
@@ -354,7 +513,10 @@ describe('snapshot schema', () => {
       });
 
       test('can approve snapshots', async () => {
-        const newSnapshot = await createSnapshot('test 1', build2, { diff: true, previousApprovedId: snapshot2.id });
+        const newSnapshot = await createSnapshot('test 1', build2, {
+          diff: true,
+          previousApprovedId: snapshot2.id,
+        });
         await createSnapshotDiff(snapshot, newSnapshot, build2, { group: 1 });
         const variables = {
           buildId: build2.id,
@@ -373,6 +535,47 @@ describe('snapshot schema', () => {
         expect(approvedSnapshots[0].id).toBe(newSnapshot.id);
         expect(approvedSnapshots[0].approvedBy.user.id).toBe(user.id);
         expect(approvedSnapshots[0].approvedOn).toBeDefined();
+      });
+      test('does not approve snapshots that have been set as a flake', async () => {
+        const oldBuild = await createBuild('oldBuild', project);
+        const oldSnapshot = await createSnapshot('old snapshot', oldBuild);
+        const newBuild = await createBuild('newBuild', project);
+        const newSnapshot = await createSnapshot('test 1', newBuild, {
+          diff: true,
+          previousApprovedId: oldSnapshot.id,
+        });
+        await createSnapshotDiff(oldSnapshot, newSnapshot, newBuild, { group: 1 });
+        const flakeQuery = `
+        mutation addSnapshotFlake($id: ID!) {
+          addSnapshotFlake(id: $id) {
+            id
+            imageLocation
+            createdBy {
+              user {
+                id
+              }
+            }
+          }
+        }
+        `;
+        let variables = {
+          id: newSnapshot.id,
+        };
+        await runQuery(flakeQuery, user, variables);
+        variables = {
+          buildId: build2.id,
+          group: 1,
+        };
+        await runQuery(query, user, variables);
+        const approvedSnapshots = await Snapshots.query()
+          .joinRelation('snapshotDiff')
+          .where('snapshot.buildId', newBuild.id)
+          .where('snapshotDiff.group', 1)
+          .where('approved', true)
+          .eager('approvedBy.user');
+        expect(approvedSnapshots).toHaveLength(0);
+        const totalSnapshots = await newBuild.$relatedQuery('snapshots');
+        expect(totalSnapshots).toHaveLength(1);
       });
     });
   });

--- a/react/src/app/snapshots/components/SnapshotGroups.jsx
+++ b/react/src/app/snapshots/components/SnapshotGroups.jsx
@@ -10,7 +10,7 @@ import {
   getGroupsPageInfo,
   getIsLoadingMoreGroups,
   getIsApproving,
-  getCurrentSnapshot,
+  getCurrentSnapshotId,
   getSnapshotGroups,
   getShowMoreFromGroup,
 } from '../../../redux/snapshots/selectors.js';
@@ -45,7 +45,7 @@ class SnapshotGroups extends React.PureComponent {
       }),
     ),
     build: PropTypes.object.isRequired,
-    currentSnapshot: PropTypes.object,
+    currentSnapshotId: PropTypes.string,
     isLoading: PropTypes.bool.isRequired,
     canApproveAll: PropTypes.bool.isRequired,
     isApproving: PropTypes.bool.isRequired,
@@ -55,10 +55,6 @@ class SnapshotGroups extends React.PureComponent {
     onApproveSnapshot: PropTypes.func.isRequired,
     onLoadMoreFromGroup: PropTypes.func.isRequired,
   };
-
-  currentSnapshotId = this.props.currentSnapshot
-    ? this.props.currentSnapshot.id
-    : null;
 
   render() {
     const typeName = 'Modified snapshots';
@@ -82,7 +78,6 @@ class SnapshotGroups extends React.PureComponent {
     const count = this.props.build.modifiedSnapshots;
     const noSnapshots = groups.length === 0 && count === 0;
     const countText = noSnapshots ? '(None)' : `(${count})`;
-
     if (noSnapshots) {
       children = null;
     } else {
@@ -126,7 +121,7 @@ class SnapshotGroups extends React.PureComponent {
                         onExpand={() => this.props.onExpand(snapshot)}
                         type={this.props.type}
                         isApproving={this.props.isApproving}
-                        active={this.currentSnapshotId === snapshot.id}
+                        active={this.props.currentSnapshotId === snapshot.id}
                         onToggleFlake={() =>
                           this.props.onToggleFlake({ group, snapshot })
                         }
@@ -138,7 +133,11 @@ class SnapshotGroups extends React.PureComponent {
                     <LoadMoreButton
                       isLoadingMore={!!this.props.isLoadingMoreFromGroup[group]}
                       onLoadMore={() => this.props.onLoadMoreFromGroup(group)}
-                      label={group.group === null ? 'Load more' : 'Load more similar snapshots'}
+                      label={
+                        group.group === null
+                          ? 'Load more'
+                          : 'Load more similar snapshots'
+                      }
                     />
                   </Box>
                 )}
@@ -183,7 +182,7 @@ const mapState = state => {
     pageInfo: getGroupsPageInfo(state),
     canApproveAll: build.approvedSnapshots < build.modifiedSnapshots,
     build,
-    currentSnapshot: getCurrentSnapshot(state),
+    currentSnapshotId: getCurrentSnapshotId(state),
   };
 };
 

--- a/react/src/app/snapshots/components/SnapshotHeader.jsx
+++ b/react/src/app/snapshots/components/SnapshotHeader.jsx
@@ -180,6 +180,15 @@ const SnapshotHeader = React.memo(
           />
         );
       }
+      if (!canExpand) {
+        return (
+          <Button
+            disabled
+            data-test-id="expand-snapshot-button"
+            icon={<Expand />}
+          />
+        )
+      }
       return (
         <Link.Button
           data-test-id="expand-snapshot-link"

--- a/react/src/app/snapshots/components/SnapshotHeader.spec.jsx
+++ b/react/src/app/snapshots/components/SnapshotHeader.spec.jsx
@@ -44,8 +44,7 @@ describe('<SnapshotHeader />', () => {
       const { getByTestId, queryByTestId } = render(
         <SnapshotHeader {...PROPS} canExpand={false} />,
       );
-      expect(queryByTestId('expand-snapshot-button')).toBeNull();
-      expect(getByTestId('expand-snapshot-link').hasAttribute('disabled')).toBe(
+      expect(getByTestId('expand-snapshot-button').hasAttribute('disabled')).toBe(
         true,
       );
     });

--- a/react/src/app/snapshots/components/SnapshotList.jsx
+++ b/react/src/app/snapshots/components/SnapshotList.jsx
@@ -11,7 +11,7 @@ import {
   getIsLoadingMore,
   getPageInfo,
   getIsApproving,
-  getCurrentSnapshot,
+  getCurrentSnapshotId,
 } from '../../../redux/snapshots/selectors.js';
 import {
   showSnapshot,
@@ -65,10 +65,6 @@ class SnapshotList extends React.PureComponent {
     }
   }
 
-  currentSnapshotId = this.props.currentSnapshot
-    ? this.props.currentSnapshot.id
-    : null;
-
   render() {
     if (this.props.isLoading) {
       return (
@@ -118,7 +114,7 @@ class SnapshotList extends React.PureComponent {
               onExpand={() => this.props.onExpand(snapshot)}
               type={this.props.type}
               isApproving={this.props.isApproving}
-              active={this.currentSnapshotId === snapshot.id}
+              active={this.props.currentSnapshotId === snapshot.id}
             />
           ))}
           {hasMore && (
@@ -155,7 +151,7 @@ const mapState = (state, { type }) => {
     pageInfo: getPageInfo(state)[type],
     isApproving: getIsApproving(state),
     build,
-    currentSnapshot: getCurrentSnapshot(state),
+    currentSnapshotId: getCurrentSnapshotId(state),
   };
 };
 

--- a/react/src/graphql/fragments/snapshot.js
+++ b/react/src/graphql/fragments/snapshot.js
@@ -8,6 +8,9 @@ fragment snapshotFragment on Snapshot {
   width
   browser
   diff
+  buildId
+  projectId
+  organizationId
   approvedBy {
     user {
       id

--- a/react/src/redux/snapshots/actions.js
+++ b/react/src/redux/snapshots/actions.js
@@ -43,28 +43,38 @@ export const doneLoadingMoreFromGroup = group => ({
 export const isApproving = () => ({ type: actionTypes.isApproving });
 export const doneApproving = () => ({ type: actionTypes.doneApproving });
 export const isLoadingGroups = () => ({ type: actionTypes.isLoadingGroups });
-export const doneLoadingGroups = () => ({ type: actionTypes.doneLoadingGroups });
-export const isLoadingMoreGroups = () => ({ type: actionTypes.isLoadingMoreGroups });
-export const doneLoadingMoreGroups = () => ({ type: actionTypes.doneLoadingMoreGroups });
-export const isAddingSnapshotFlake = () => ({ type: actionTypes.isAddingSnapshotFlake });
-export const doneAddingSnapshotFlake = () => ({ type: actionTypes.doneAddingSnapshotFlake });
+export const doneLoadingGroups = () => ({
+  type: actionTypes.doneLoadingGroups,
+});
+export const isLoadingMoreGroups = () => ({
+  type: actionTypes.isLoadingMoreGroups,
+});
+export const doneLoadingMoreGroups = () => ({
+  type: actionTypes.doneLoadingMoreGroups,
+});
+export const isAddingSnapshotFlake = () => ({
+  type: actionTypes.isAddingSnapshotFlake,
+});
+export const doneAddingSnapshotFlake = () => ({
+  type: actionTypes.doneAddingSnapshotFlake,
+});
 
 export const setError = error => ({
   type: actionTypes.setError,
   error,
 });
 
-export const receiveGroups = (groups) => ({
+export const receiveGroups = groups => ({
   type: actionTypes.receiveGroups,
   groups,
 });
 
-export const addGroups = (groups) => ({
+export const addGroups = groups => ({
   type: actionTypes.addGroups,
   groups,
 });
 
-export const updateGroupsPageInfo = (groups) => ({
+export const updateGroupsPageInfo = groups => ({
   type: actionTypes.updateGroupsPageInfo,
   groups,
 });
@@ -104,7 +114,7 @@ export const addSnapshots = (snapshotType, snapshots) => ({
   snapshotType,
 });
 
-export const approveSnapshots = (snapshot) => ({
+export const approveSnapshots = snapshot => ({
   type: actionTypes.approveSnapshots,
   snapshot,
 });
@@ -166,10 +176,10 @@ export const getSnapshot = id => async (dispatch, getState) => {
         dispatch(addSnapshot('single', snapshot));
       }
       if (currentOrganizationId !== snapshot.organizationId) {
-        dispatch(changeOrganization(snapshot.organizationId));
+        dispatch(changeOrganization({ id: snapshot.organizationId }));
       }
       if (currentProjectId !== snapshot.projectId) {
-        dispatch(changeProject(snapshot.projectId));
+        dispatch(changeProject({ id: snapshot.projectId }));
       }
       if (currentBuildId !== snapshot.buildId) {
         dispatch(changeBuild({ id: snapshot.buildId }));
@@ -228,14 +238,16 @@ export const getSnapshotGroups = () => async (dispatch, getState) => {
     });
 
     if (data.modifiedSnapshotGroups) {
-      dispatch(receiveGroups(data.modifiedSnapshotGroups.edges.map(e => e.node)));
+      dispatch(
+        receiveGroups(data.modifiedSnapshotGroups.edges.map(e => e.node)),
+      );
       dispatch(updateGroupsPageInfo(data.modifiedSnapshotGroups));
     }
     dispatch(doneLoadingGroups());
   } catch (error) {
     dispatch(doneLoadingGroups());
   }
-}
+};
 
 export const loadMoreGroups = () => async (dispatch, getState) => {
   const state = getState();
@@ -263,7 +275,7 @@ export const loadMoreGroups = () => async (dispatch, getState) => {
   } catch (error) {
     dispatch(doneLoadingMoreGroups());
   }
-}
+};
 
 export const loadMoreFromGroup = group => async (dispatch, getState) => {
   const state = getState();
@@ -286,13 +298,15 @@ export const loadMoreFromGroup = group => async (dispatch, getState) => {
 
     if (data.modifiedSnapshots) {
       dispatch(addSnapshotsToGroup(group, data.modifiedSnapshots.edges));
-      dispatch(updateGroupSnapshotsPageInfo(group, data.modifiedSnapshots.pageInfo))
+      dispatch(
+        updateGroupSnapshotsPageInfo(group, data.modifiedSnapshots.pageInfo),
+      );
     }
     dispatch(doneLoadingMoreFromGroup(group.group));
   } catch (error) {
     dispatch(doneLoadingMoreFromGroup(group.group));
   }
-}
+};
 
 export const setCurrentSnapshot = currentSnapshotId => ({
   type: actionTypes.setCurrentSnapshot,
@@ -325,7 +339,9 @@ export const approveSnapshot = ({ group, snapshot }) => async dispatch => {
     });
     if (data.approveSnapshot) {
       dispatch(updateGroupSnapshot(group, data.approveSnapshot));
-      dispatch(updateGroupApprovedSnapshots(group, group.approvedSnapshots + 1));
+      dispatch(
+        updateGroupApprovedSnapshots(group, group.approvedSnapshots + 1),
+      );
       dispatch(updateApprovedSnapshots(1));
     }
     dispatch(doneApproving());
@@ -367,7 +383,7 @@ export const approveAllSnapshots = () => async (dispatch, getState) => {
   }
 };
 
-export const approveGroupSnapshots = (group) => async (dispatch, getState) => {
+export const approveGroupSnapshots = group => async (dispatch, getState) => {
   const state = getState();
   const user = getUser(state);
   const { currentBuildId } = state.builds;
@@ -430,7 +446,10 @@ export const loadMore = type => async (dispatch, getState) => {
   }
 };
 
-export const addSnapshotFlake = ({ group, snapshot }) => async (dispatch, getState) => {
+export const addSnapshotFlake = ({ group, snapshot }) => async (
+  dispatch,
+  getState,
+) => {
   dispatch(isAddingSnapshotFlake());
   try {
     const { data } = await ApolloClient.mutate({
@@ -440,10 +459,12 @@ export const addSnapshotFlake = ({ group, snapshot }) => async (dispatch, getSta
       },
     });
     if (data.addSnapshotFlake) {
-      dispatch(updateGroupSnapshot(group, {
-        id: snapshot.id,
-        snapshotFlake: data.addSnapshotFlake,
-      }));
+      dispatch(
+        updateGroupSnapshot(group, {
+          id: snapshot.id,
+          snapshotFlake: data.addSnapshotFlake,
+        }),
+      );
     }
     dispatch(doneAddingSnapshotFlake());
   } catch (error) {

--- a/react/src/redux/snapshots/actions.spec.js
+++ b/react/src/redux/snapshots/actions.spec.js
@@ -672,6 +672,9 @@ beforeEach(() => {
     snapshotDiff: null,
     title: 'Project list - all',
     width: 1280,
+    projectId: '12345',
+    organizationId: '1234',
+    buildId: '54321',
     __typename: 'Snapshot',
   };
   snapshotsData = {

--- a/react/src/redux/snapshots/selectors.js
+++ b/react/src/redux/snapshots/selectors.js
@@ -6,6 +6,7 @@ export const getCurrentSnapshot = state =>
   state.snapshots.snapshots.single.find(
     b => b.id === state.snapshots.currentSnapshotId,
   );
+export const getCurrentSnapshotId = state => state.snapshots.currentSnapshotId;
 export const getPageInfo = state => state.snapshots.pageInfo;
 export const getIsLoadingMore = state => state.snapshots.isLoadingMore;
 export const getIsApproving = state => state.snapshots.isApproving;


### PR DESCRIPTION
fixes #20 
- checks for remaining modified snapshots, if there are 0 then verify build.
- also stops snapshots that are set as a flake from being approved.

TODO:
- update removed and approvedSnapshots to include flakes if applicable.