### PR TITLE
fix(assets) - select DOM nodes with attribute

### DIFF
--- a/express/app/utils/stream-transformer.js
+++ b/express/app/utils/stream-transformer.js
@@ -44,9 +44,9 @@ const transformHTML = (assets, assetsUrl, relativePath) => {
   };
   const stream = trumpet();
 
-  stream.selectAll('img', element => updateAttribute('src', element));
-  stream.selectAll('script', element => updateAttribute('src', element));
-  stream.selectAll('link', element => updateAttribute('href', element));
+  stream.selectAll('img[src]', element => updateAttribute('src', element));
+  stream.selectAll('script[src]', element => updateAttribute('src', element));
+  stream.selectAll('link[href]', element => updateAttribute('href', element));
   stream.selectAll('style', element => {
     let elementStream = element.createStream();
     elementStream

--- a/express/tests/unit/utils/stream-transformer.test.js
+++ b/express/tests/unit/utils/stream-transformer.test.js
@@ -104,6 +104,20 @@ describe('stream transformer', () => {
         `<html><head><style>body { background-image: url(${baseUrl}/${assetPath[0]}); } div { background-image: url(${baseUrl}/${assetPath[1]}); }</style></head><body><div>Test</div></body></html>`,
       );
     });
+    it('should not modify elements who do not have the attribute', async () => {
+      const stream = new Readable();
+      stream.push(
+        `<html><head><link hef="broke" /><script>console.log('test');</script><body><div>Test</div><img scr="whoops"/></body></html>`,
+      );
+      stream.push(null);
+
+      const returnedStream = transform.transformHTML(assets, baseUrl, '');
+      stream.pipe(returnedStream);
+      const data = await readStream(returnedStream);
+      expect(data).toBe(
+        `<html><head><link hef="broke" /><script>console.log('test');</script><body><div>Test</div><img scr="whoops"/></body></html>`,
+      );
+    })
   });
 
   test('transformCSS', async () => {


### PR DESCRIPTION
fixes #25 
- ensures selectors include attributes that are checked for asset urls