### PR TITLE
Specify compare branch

### DIFF
--- a/express/app/models/Build.js
+++ b/express/app/models/Build.js
@@ -102,7 +102,7 @@ class Build extends BaseModel {
     }
   }
 
-  async getPreviousBuild(project = null) {
+  async getPreviousBuild({project = null, compareBranch = null} = {}) {
     if (!project) {
       project = await this.$relatedQuery('project');
     }
@@ -110,7 +110,7 @@ class Build extends BaseModel {
     let baseSHA = null;
     let baseBuild = null;
 
-    if (project.hasSCM && this.commitSha && this.branch) {
+    if (project.hasSCM && this.commitSha && (compareBranch || this.branch)) {
       this.notifyPending(project);
 
       const pullRequests = await getPRs({
@@ -139,7 +139,7 @@ class Build extends BaseModel {
       .first();
 
     if (isPR) {
-      baseBuild = await baseQuery.clone().where('branch', this.branch);
+      baseBuild = await baseQuery.clone().where('branch', compareBranch || this.branch);
 
       if (!baseBuild && baseSHA) {
         baseBuild = await baseQuery.clone().where('commitSha', baseSHA);
@@ -151,7 +151,7 @@ class Build extends BaseModel {
         .where('branch', project.defaultBranch);
     }
     if (!baseBuild && !isPR) {
-      baseBuild = await baseQuery.clone().where('branch', this.branch);
+      baseBuild = await baseQuery.clone().where('branch', compareBranch || this.branch);
     }
 
     return baseBuild;

--- a/express/app/models/Build.js
+++ b/express/app/models/Build.js
@@ -148,7 +148,7 @@ class Build extends BaseModel {
     if (!baseBuild) {
       baseBuild = await baseQuery
         .clone()
-        .where('branch', project.defaultBranch);
+        .where('branch', compareBranch || project.defaultBranch);
     }
     if (!baseBuild && !isPR) {
       baseBuild = await baseQuery.clone().where('branch', compareBranch || this.branch);

--- a/express/app/routes/build.js
+++ b/express/app/routes/build.js
@@ -33,7 +33,9 @@ router.post('/start', async (req, res) => {
 
   let build = Build.fromJson(data);
 
-  const baseBuild = await build.getPreviousBuild(project);
+  const compareBranch = req.body.compareBranch || null;
+
+  const baseBuild = await build.getPreviousBuild({project, compareBranch});
   let missingAssets = [];
 
   if (baseBuild) {

--- a/express/app/routes/build.js
+++ b/express/app/routes/build.js
@@ -34,7 +34,7 @@ router.post('/start', async (req, res) => {
   let build = Build.fromJson(data);
 
   const compareBranch = req.body.compareBranch || null;
-
+  console.log(compareBranch)
   const baseBuild = await build.getPreviousBuild({project, compareBranch});
   let missingAssets = [];
 

--- a/express/app/tasks/queueTask.js
+++ b/express/app/tasks/queueTask.js
@@ -17,14 +17,10 @@ const queueTask = async message => {
     try {
       await channel.assertQueue(settings.ampq.taskQueue, { durable: true });
 
-      for await (const messageData of messages) {
-        const message = JSON.stringify(messageData);
-        console.log('sending', message);
-        await channel.sendToQueue(settings.ampq.taskQueue, Buffer.from(message), {
-          deliveryMode: true,
-        });
-      }
-
+      const messageData = JSON.stringify(message);
+      await channel.sendToQueue(settings.ampq.taskQueue, Buffer.from(messageData), {
+        deliveryMode: true,
+      });
       await channel.close();
       await connection.close();
     } catch (error) {

--- a/express/package.json
+++ b/express/package.json
@@ -8,8 +8,8 @@
     "dev:debug": "DEBUG=knex* nodemon ./bin/www",
     "start": "node ./bin/www",
     "migrate": "knex migrate:latest",
-    "test:unit": "jest -c tests/unit/config/config.js",
-    "test:selenium": "jest -c tests/selenium/config/config.js"
+    "test:unit": "jest -c tests/unit/config/config.js -i",
+    "test:selenium": "jest -c tests/selenium/config/config.js -i"
   },
   "author": "",
   "license": "AGPLv3",

--- a/express/tests/unit/models/Build.test.js
+++ b/express/tests/unit/models/Build.test.js
@@ -161,7 +161,7 @@ describe('Build', () => {
       });
       const prBuild = await createBuild('repoBranch', project2);
       prBuild.notifyPending = jest.fn();
-      expect(await prBuild.getPreviousBuild(project2)).toEqual(firstBuild);
+      expect(await prBuild.getPreviousBuild({project: project2})).toEqual(firstBuild);
       expect(prBuild.notifyPending).toHaveBeenCalled();
     });
 
@@ -185,7 +185,7 @@ describe('Build', () => {
         completedAt: Build.knex().fn.now(),
       });
       const newBuild = await createBuild('otherBranch', project2);
-      expect(await newBuild.getPreviousBuild(project2)).toEqual(baseBuild);
+      expect(await newBuild.getPreviousBuild({project: project2})).toEqual(baseBuild);
     });
 
     it('should return the previous build based on the last branch', async () => {
@@ -194,7 +194,7 @@ describe('Build', () => {
         completedAt: Build.knex().fn.now(),
       });
       const newBuild = await createBuild('diffBranch', project);
-      expect(await newBuild.getPreviousBuild(project)).toEqual(baseBuild);
+      expect(await newBuild.getPreviousBuild({project: project})).toEqual(baseBuild);
     });
 
     it('should return the previous build based on a project default branch', async () => {
@@ -203,7 +203,7 @@ describe('Build', () => {
         completedAt: Build.knex().fn.now(),
       });
       const newBuild = await createBuild('diffBranch', project);
-      expect(await newBuild.getPreviousBuild(project)).toEqual(baseBuild);
+      expect(await newBuild.getPreviousBuild({project,})).toEqual(baseBuild);
     });
 
     it('should return undefined if no previous build is found', async () => {


### PR DESCRIPTION
- enables an option to provide the base branch to use for comparison
- fixes an issue when using rabbitmq locally for worker tasks
- adds -i to jest selenium and unit tests -to disable parallelism as some tests will have database conflicts