### PR TITLE
Modify snapshot keys

### DIFF
--- a/express/app/routes/snapshots.js
+++ b/express/app/routes/snapshots.js
@@ -10,7 +10,7 @@ router.get('*', async (req, res) => {
   if (token !== settings.token) {
     return res.send(404);
   }
-  const key = req.params[0];
+  const key = req.params[0].slice(1);
   const stream = s3
     .getObject({
       Bucket: settings.s3.assetsBucket,
@@ -18,7 +18,10 @@ router.get('*', async (req, res) => {
     })
     .createReadStream();
 
-  stream.on('error', err => res.status(400).json({ error: err.message }));
+  stream.on('error', err => {
+    console.error(err);
+    res.status(400).json({error: err.message});
+  });
 
   return stream.pipe(res);
 });

--- a/express/app/utils/upload.js
+++ b/express/app/utils/upload.js
@@ -4,7 +4,7 @@ const mime = require('mime-types');
 const crypto = require('crypto');
 const uuidv4 = require('uuid/v4');
 
-const { getAssetsPath } = require('./build');
+const {getAssetsPath} = require('./build');
 const transformer = require('./stream-transformer');
 const settings = require('../settings');
 const s3 = require('../utils/s3config');
@@ -15,7 +15,7 @@ const assetsUrl = settings.s3.privateAssets
 
 const createBucket = async bucket => {
   try {
-    await s3.createBucket({ Bucket: bucket }).promise();
+    await s3.createBucket({Bucket: bucket}).promise();
   } catch (error) {
     console.log('there was an error creating the bucket!');
     console.error(error);
@@ -26,7 +26,7 @@ const createBucket = async bucket => {
 const checkBucket = async bucket => {
   console.log('checking bucket exists');
   try {
-    await s3.headBucket({ Bucket: bucket }).promise();
+    await s3.headBucket({Bucket: bucket}).promise();
     return true;
   } catch (error) {
     if (error.statusCode === 404) {
@@ -52,10 +52,9 @@ const getSnapshotContentType = (req, file, cb) => {
 const getSnapshotKey = (req, file, cb) => {
   const build = req.locals.build;
   const randomValue = crypto.randomBytes(16).toString('hex');
-  const relativePath = req.headers['x-relative-path'] || 'base';
   let key = `${build.organizationId}/${build.projectId}/${
     build.id
-  }/${relativePath}/${randomValue}.html`;
+  }/${randomValue}.html`;
   console.log(`uploading: ${key}`);
 
   cb(null, key);

--- a/express/tests/unit/utils/upload.test.js
+++ b/express/tests/unit/utils/upload.test.js
@@ -110,7 +110,7 @@ describe('upload utils', () => {
     upload.getSnapshotKey(req, {}, cb);
     expect(cb).toHaveBeenCalledWith(
       null,
-      expect.stringContaining('3/2/1/base'),
+      expect.stringContaining('3/2/1/'),
     );
   });
 


### PR DESCRIPTION
the s3 aws sdk encodes Keys. Which causes issues for other "compliant" s3 services. Removing `relativePath` from the snapshot key solves this issue. We also remove the leading slash for the `snapshot_source` endpoint