### PR TITLE
chore(infra): move worker task into crontab

### DIFF
--- a/express/app/integrations/bitbucket/pullRequest.js
+++ b/express/app/integrations/bitbucket/pullRequest.js
@@ -39,7 +39,7 @@ const getBaseSHA = async (project, sha) => {
   if (pullRequests.values && pullRequests.values.length > 0) {
     const pullRequestData = await getPullRequest({
       url: pullRequests.values[0].links.self.href,
-      token,
+      token: project.scmToken,
     });
 
     return pullRequestData.destination.commit.hash;

--- a/express/app/integrations/github/pullRequest.js
+++ b/express/app/integrations/github/pullRequest.js
@@ -39,7 +39,7 @@ const getBaseSHA = async (project, sha) => {
   if (pullRequests && pullRequests.length > 0) {
     const pullRequestData = await getPullRequest({
       url: pullRequests[0].pull_request.url,
-      token,
+      token: project.scmToken,
     });
 
     return pullRequestData.base.sha;

--- a/express/app/tasks/cronTasks.js
+++ b/express/app/tasks/cronTasks.js
@@ -1,0 +1,16 @@
+const Build = require('../models/Build');
+
+const { checkBuild } = require('./builds');
+
+const cronTasks = async () => {
+  const builds = await Build
+    .query()
+    .whereNull('completedAt')
+    .orWhereNot('error', true);
+
+  for await (const build of builds) {
+    await checkBuild(build);
+  }
+};
+
+cronTasks();

--- a/express/app/tasks/queueTask.js
+++ b/express/app/tasks/queueTask.js
@@ -1,18 +1,12 @@
 const aws = require('aws-sdk');
 
-const connection = require('../utils/amqpConnection');
 const settings = require('../settings');
 const actionTypes = require('./actionTypes');
 
-let channelWrapper;
 let sqs;
 
 if (settings.sqs.use) {
   sqs = new aws.SQS({ apiVersion: '2012-11-05' });
-} else if (settings.amqp.use && !process.env.TEST) {
-  channelWrapper = connection.createChannel({
-    setup: (channel) => channel.assertQueue(settings.amqp.taskQueue, { durable: true }),
-  })
 }
 
 const queueTask = async message => {
@@ -23,15 +17,6 @@ const queueTask = async message => {
         MessageBody: JSON.stringify(message),
       })
       .promise();
-  } else if (settings.amqp.use) {
-    const messageData = JSON.stringify(message);
-    await channelWrapper.sendToQueue(
-      settings.amqp.taskQueue,
-      Buffer.from(messageData),
-      {
-        deliveryMode: true,
-      },
-    );
   }
 };
 

--- a/infrastructure/kube/app/worker-job.yaml
+++ b/infrastructure/kube/app/worker-job.yaml
@@ -1,0 +1,19 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: basset-worker
+spec:
+  schedule: "*/5 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: basset-worker
+              image: getbasset/basset-app:release-1.0.0-beta-3
+              command: ["node"]
+              args: ["app/tasks/cronTasks.js"]
+              envFrom:
+                - configMapRef:
+                    name: basset-app-config
+          restartPolicy: OnFailure


### PR DESCRIPTION
This PR removes queuing tasks through rabbitmq. Instead it uses a kubernetes crontab to run the build checker task