### PR TITLE
fix(app): move amqp connection logic to app scaffolding

### DIFF
--- a/express/app/app.js
+++ b/express/app/app.js
@@ -168,4 +168,12 @@ app.get('*', csrfProtection, (req, res) => {
 
 const render = ['index', {settings}];
 
+if (!process.env.TEST) {
+  const configureConnection = require('./utils/amqpConnection');
+  const configureQueue = require('./tasks/queueCompareSnapshots');
+
+  configureConnection();
+  configureQueue();
+}
+
 module.exports = app;

--- a/express/app/models/Snapshot.js
+++ b/express/app/models/Snapshot.js
@@ -94,6 +94,7 @@ class Snapshot extends BaseModel {
             snapshotFromId: this.previousApprovedId,
             snapshotToId: this.id,
             buildId: this.buildId,
+            organizationId: this.organizationId,
           });
         }
       }

--- a/express/app/schema/snapshot.js
+++ b/express/app/schema/snapshot.js
@@ -609,11 +609,9 @@ const checkModifiedAndNotify = async build => {
   const { modifiedSnapshotCount } = await Snapshot.query()
     .where('buildId', build.id)
     .where('diff', true)
-    .where(builder => {
-      builder.where('approved', false).orWhere(builder => {
-        builder.where('flake', true).whereNull('snapshotFlakeMatchedId');
-      });
-    })
+    .whereNot('approved', true)
+    .whereNot('flake', true)
+    .whereNull('snapshotFlakeMatchedId')
     .count('snapshot.id as modifiedSnapshotCount')
     .first();
 

--- a/express/app/tasks/builds.js
+++ b/express/app/tasks/builds.js
@@ -16,7 +16,7 @@ const checkBuild = async (build) => {
   const timeDelta = lastUpdated - build.updatedAt;
   if (timeDelta > buildTimeout) {
     console.error(
-      `Build (id: ${build.id}) has timed out. There were${
+      `[checkBuilds] Build (id: ${build.id}) has timed out. There were${
         lastSnapshot ? '' : ' no'
       } snapshots created.`,
     );

--- a/express/app/tasks/cronTasks.js
+++ b/express/app/tasks/cronTasks.js
@@ -1,8 +1,11 @@
+const db = require('../db');
 const Build = require('../models/Build');
-
 const { checkBuild } = require('./builds');
 
+const knex = db.configure();
+
 const cronTasks = async () => {
+  console.log('[checkBuilds] checking for timed out builds');
   const builds = await Build
     .query()
     .whereNull('completedAt')
@@ -11,6 +14,13 @@ const cronTasks = async () => {
   for await (const build of builds) {
     await checkBuild(build);
   }
+  console.log('[checkBuilds] complete');
+  await destroy();
+};
+
+const destroy = async () => {
+  await knex.destroy();
+  process.exitCode = 1;
 };
 
 cronTasks();

--- a/express/app/utils/amqpConnection.js
+++ b/express/app/utils/amqpConnection.js
@@ -1,9 +1,16 @@
 const amqp = require('amqp-connection-manager');
 const settings = require('../settings');
 
-let connection;
-if (settings.amqp.use && !process.env.TEST) { // selenium cannot run if amqplib is trying to reconnect
-  connection = amqp.connect([settings.amqp.host]);
-}
 
-module.exports = connection;
+let connection;
+
+const configureConnection = () => {
+  if (settings.amqp.use && !process.env.TEST) {
+    connection = amqp.connect([settings.amqp.host]);
+  }
+};
+
+module.exports = {
+  connection,
+  configureConnection,
+};

--- a/express/tests/unit/tasks/queueCompareSnapshots.test.js
+++ b/express/tests/unit/tasks/queueCompareSnapshots.test.js
@@ -1,16 +1,17 @@
 let mockSendToQueue = jest.fn(async () => {});
-jest.mock('amqp-connection-manager', () => ({
-  connect: jest.fn(() => ({
+
+jest.mock('../../../app/utils/amqpConnection', () => ({
+  connection: {
     createChannel: jest.fn(() => ({
       sendToQueue: mockSendToQueue,
     })),
-  })),
-}));
-
+  }
+}))
 const tasks = require('../../../app/tasks/queueCompareSnapshots');
 
 describe('queueCompareSnapshots', () => {
   test('it sends messages to amqplib', async () => {
+    tasks.configureQueue();
     const messages = [{ test: 1 }, { test: 2 }, { test: 3 }];
     await tasks.queueCompareSnapshots(messages);
     expect(mockSendToQueue).toHaveBeenCalledTimes(3);

--- a/react/src/app/snapshots/components/SnapshotList.jsx
+++ b/react/src/app/snapshots/components/SnapshotList.jsx
@@ -50,7 +50,7 @@ class SnapshotList extends React.PureComponent {
     }
     if (type === 'unmodified') {
       return (
-        build.totalSnapshots - build.modifiedSnapshots - build.newSnapshots
+        build.totalSnapshots - build.modifiedSnapshots - build.newSnapshots - build.flakedSnapshots
       );
     }
     if (type === 'new') {


### PR DESCRIPTION
This PR moves the amqp connection manager logic into app.js. The way amqp-connection-manager is imported is causing issues for any node scripts that need to run. This PR resolves that issue

- fixed some additional issues found