### PR TITLE
Add snapshot and data retention limits

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /basset-react/
 COPY react /basset-react
 RUN npm install
 RUN npm run build
-RUN mv -f dist ../basset/statisc
+RUN mv -f dist ../basset/static
 # cleanup files not needed
 RUN rm -rf /basset-react
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,9 @@ WORKDIR /basset-react/
 COPY react /basset-react
 RUN npm install
 RUN npm run build
-RUN mv -f dist ../basset/static
+RUN mv -f dist ../basset/statisc
 # cleanup files not needed
-RUN rm -rf /basse-react
+RUN rm -rf /basset-react
 
 # run server
 WORKDIR /basset/

--- a/express/app/integrations/bitbucket/index.js
+++ b/express/app/integrations/bitbucket/index.js
@@ -4,6 +4,7 @@ const {
   snapshotsNeedApproving,
   snapshotsNoDiffs,
   snapshotsApproved,
+  snapshotsExceeded
 } = require('./status');
 
 module.exports = {
@@ -12,4 +13,5 @@ module.exports = {
   snapshotsNeedApproving,
   snapshotsNoDiffs,
   snapshotsApproved,
+  snapshotsExceeded,
 };

--- a/express/app/integrations/bitbucket/status.js
+++ b/express/app/integrations/bitbucket/status.js
@@ -81,6 +81,20 @@ const snapshotsNoDiffs = (project, build) => {
   });
 };
 
+
+const snapshotsExceeded = (project, build) => {
+  return updateStatus({
+    token: project.scmToken,
+    username: project.scmConfig.username,
+    repoSlug: project.scmConfig.repoSlug,
+    sha: build.commitSha,
+    url: `${settings.site.url}`,
+    state: 'FAILED',
+    description: 'Monthly snapshot limit has been exceeded',
+    context: 'Basset',
+  });
+};
+
 const snapshotsNeedApproving = (project, build) => {
   return updateStatus({
     token: project.scmToken,
@@ -99,4 +113,5 @@ module.exports = {
   snapshotsApproved,
   snapshotsNeedApproving,
   snapshotsNoDiffs,
+  snapshotsExceeded,
 };

--- a/express/app/integrations/github/index.js
+++ b/express/app/integrations/github/index.js
@@ -4,6 +4,7 @@ const {
   snapshotsNeedApproving,
   snapshotsNoDiffs,
   snapshotsApproved,
+  snapshotsExceeded,
 } = require('./status');
 
 module.exports = {
@@ -12,4 +13,5 @@ module.exports = {
   snapshotsNeedApproving,
   snapshotsNoDiffs,
   snapshotsApproved,
+  snapshotsExceeded,
 };

--- a/express/app/integrations/github/status.js
+++ b/express/app/integrations/github/status.js
@@ -80,6 +80,19 @@ const snapshotsNoDiffs = (project, build) => {
   });
 };
 
+const snapshotsExceeded = (project, build) => {
+  return updateStatus({
+    token: project.scmToken,
+    owner: project.scmConfig.repoOwner,
+    repo: project.scmConfig.repoName,
+    sha: build.commitSha,
+    url: `${settings.site.url}`,
+    state: 'failure',
+    description: 'Monthly snapshot limit has been exceeded',
+    context: 'Basset',
+  });
+};
+
 const snapshotsNeedApproving = (project, build) => {
   return updateStatus({
     token: project.scmToken,
@@ -97,5 +110,6 @@ module.exports = {
   snapshotsPending,
   snapshotsApproved,
   snapshotsNeedApproving,
+  snapshotsExceeded,
   snapshotsNoDiffs,
 };

--- a/express/app/integrations/gitlab/index.js
+++ b/express/app/integrations/gitlab/index.js
@@ -4,6 +4,7 @@ const {
   snapshotsNeedApproving,
   snapshotsNoDiffs,
   snapshotsApproved,
+  snapshotsExceeded,
 } = require('./status');
 
 module.exports = {
@@ -12,4 +13,5 @@ module.exports = {
   snapshotsNeedApproving,
   snapshotsNoDiffs,
   snapshotsApproved,
+  snapshotsExceeded,
 };

--- a/express/app/integrations/gitlab/status.js
+++ b/express/app/integrations/gitlab/status.js
@@ -71,6 +71,20 @@ const snapshotsNoDiffs = (project, build) => {
   });
 };
 
+
+const snapshotsExceeded = (project, build) => {
+  return updateStatus({
+    token: project.scmToken,
+    projectId: project.scmConfig.projectId,
+    sha: build.commitSha,
+    url: `${settings.site.url}`,
+    state: 'failed',
+    description: 'Monthly snapshot limit has been exceeded',
+    context: 'Basset',
+  });
+};
+
+
 const snapshotsNeedApproving = (project, build) => {
   return updateStatus({
     token: project.scmToken,
@@ -88,4 +102,5 @@ module.exports = {
   snapshotsApproved,
   snapshotsNeedApproving,
   snapshotsNoDiffs,
+  snapshotsExceeded,
 };

--- a/express/app/integrations/scm.js
+++ b/express/app/integrations/scm.js
@@ -1,7 +1,11 @@
 const github = require('./github');
 const gitlab = require('./gitlab');
+const bitbucket = require('./bitbucket');
 
 const getSCM = project => {
+  if (project.scmProvider === 'bitbucket') {
+    return bitbucket;
+  }
   if (project.scmProvider === 'github') {
     return github;
   }

--- a/express/app/models/Asset.js
+++ b/express/app/models/Asset.js
@@ -24,6 +24,7 @@ class Asset extends BaseModel {
   static get relationMappings() {
     const Organization = require('./Organization');
     const Project = require('./Project');
+    const BuildAsset = require('./BuildAsset');
     return {
       organization: {
         relation: Model.BelongsToOneRelation,
@@ -41,6 +42,14 @@ class Asset extends BaseModel {
           to: 'project.id',
         },
       },
+      buildAssets: {
+        relation: Model.HasManyRelation,
+        modelClass: BuildAsset,
+        join: {
+          from: 'asset.id',
+          to: 'buildAsset.assetId',
+        }
+      }
     };
   }
 

--- a/express/app/models/Build.js
+++ b/express/app/models/Build.js
@@ -257,6 +257,7 @@ class Build extends BaseModel {
     const Organization = require('./Organization');
     const OrganizationMember = require('./OrganizationMember');
     const Project = require('./Project');
+    const Asset = require('./Asset');
     return {
       previousBuild: {
         relation: Model.HasOneRelation,
@@ -314,6 +315,18 @@ class Build extends BaseModel {
           to: 'buildAsset.buildId',
         },
       },
+      assets: {
+        relation: Model.ManyToManyRelation,
+        modelClass: Asset,
+        join: {
+          from: 'build.id',
+          through: {
+            from: 'buildAsset.buildId',
+            to: 'buildAsset.assetId',
+          },
+          to: 'asset.id',
+        },
+      }
     };
   }
 

--- a/express/app/models/Build.js
+++ b/express/app/models/Build.js
@@ -84,6 +84,18 @@ class Build extends BaseModel {
     }
   }
 
+  async notifySnapshotsExceeded(trx = null, project = null) {
+    if (!project) {
+      project = await this.$relatedQuery('project');
+    }
+    await this.$query(trx).update({
+      error: true,
+    });
+    if (project.hasSCM) {
+      project.scm.snapshotsExceeded(project, this);
+    }
+  }
+
   async notifyNoChanges(trx = null, project = null) {
     if (!project) {
       project = await this.$relatedQuery('project');

--- a/express/app/models/Organization.js
+++ b/express/app/models/Organization.js
@@ -37,6 +37,7 @@ class Organization extends BaseModel {
     const User = require('./User');
     const OrganizationMember = require('./OrganizationMember');
     const Project = require('./Project');
+    const Snapshot = require('./Snapshot');
     return {
       organizationMembers: {
         relation: Model.HasManyRelation,
@@ -69,6 +70,14 @@ class Organization extends BaseModel {
           to: 'project.organizationId',
         },
       },
+      snapshots: {
+        relation: Model.HasManyRelation,
+        modelClass: Snapshot,
+        join: {
+          from: 'organization.id',
+          to: 'snapshot.organizationId',
+        }
+      }
     };
   }
 

--- a/express/app/models/Organization.js
+++ b/express/app/models/Organization.js
@@ -23,14 +23,33 @@ class Organization extends BaseModel {
   }
 
   async canCreate(user) {
-    if (settings.site.private) {
-      return user.admin;
-    }
-    return true;
+    return user.canCreateOrganizations();
   }
 
   static authorizationFilter(user) {
     return this.query().whereIn('id', user.organizations.map(o => o.id));
+  }
+
+  async snapshotLimitExceeded() {
+    if (!this.enforceSnapshotLimit) {
+      return false;
+    }
+    const count = await this.currentSnapshotCount;
+    return count >= this.monthlySnapshotLimit;
+  }
+
+  get currentSnapshotCount() {
+    const date = new Date();
+    const year = date.getFullYear();
+    const month = date.getMonth();
+    const firstOfMonth = new Date(year, month, 1);
+    const lastOfMonth = new Date(year, month + 1, 0);
+    return this
+      .$query()
+      .joinRelation('snapshots')
+      .whereBetween('snapshots.createdAt', [ firstOfMonth, lastOfMonth ])
+      .count()
+      .then(({ count }) => count);
   }
 
   static get relationMappings() {

--- a/express/app/routes/build.js
+++ b/express/app/routes/build.js
@@ -16,7 +16,9 @@ router.post('/start', async (req, res) => {
   if (!project) {
     return res.status(403).json({ error: 'Invalid token' });
   }
-
+  if (await project.organization.snapshotLimitExceeded()) {
+    return res.status(403).json({ error: 'Monthly snapshot limit exceeded'})
+  }
   const data = {
     branch: req.body.branch,
     commitSha: req.body.commitSha,

--- a/express/app/schema/organization.js
+++ b/express/app/schema/organization.js
@@ -84,6 +84,8 @@ const resolvers = {
       const { user } = context.req;
       let organization = Organization.fromJson({
         name,
+        enforceSnapshotLimit: settings.enforceSnapshotLimit,
+        enforceBuildRetention: settings.enforceBuildRetention,
       });
 
       if (!(await organization.canCreate(user))) {
@@ -94,8 +96,6 @@ const resolvers = {
       await OrganizationMember.query().insertAndFetch({
         organizationId: organization.id,
         userId: user.id,
-        enforceSnapshotLimit: settings.enforceSnapshotLimit,
-        enforceBuildRetention: settings.enforceBuildRetention,
         admin: true,
       });
       return organization;

--- a/express/app/schema/organization.js
+++ b/express/app/schema/organization.js
@@ -16,8 +16,8 @@ type Organization implements Node {
   monthlySnapshotLimit: Int
   currentSnapshotCount: Int
   enforceSnapshotLimit: Boolean
-  snapshotRetentionPeriod: Int
-  enforceSnapshotRetention: Boolean
+  buildRetentionPeriod: Int
+  enforceBuildRetention: Boolean
   projects(first: Int, last: Int, after: String, before: String): ProjectConnection @cost(multipliers: ["first", "last"], complexity: 1)
   organizationMembers(first: Int, last: Int, after: String, before: String): OrganizationMemberConnection @cost(multipliers: ["first", "last"], complexity: 1)
 }
@@ -95,7 +95,7 @@ const resolvers = {
         organizationId: organization.id,
         userId: user.id,
         enforceSnapshotLimit: settings.enforceSnapshotLimit,
-        enforceSnapshotRetention: settings.enforceSnapshotRetention,
+        enforceBuildRetention: settings.enforceBuildRetention,
         admin: true,
       });
       return organization;

--- a/express/app/settings.js
+++ b/express/app/settings.js
@@ -28,7 +28,7 @@ const secret = process.env.BASSET_SECRET;
 const env = process.env.NODE_ENV;
 
 const enforceSnapshotLimit = process.env.ENFORCE_SNAPSHOT_LIMIT || false;
-const enforceSnapshotRetention = process.env.ENFORCE_SNAPSHOT_RENTETION || false;
+const enforceBuildRetention = process.env.ENFORCE_BUILD_RENTETION || false;
 
 const cors = {
   origin: process.env.BASSET_ORIGIN,
@@ -127,5 +127,5 @@ module.exports = {
   session,
   saml,
   enforceSnapshotLimit,
-  enforceSnapshotRetention
+  enforceBuildRetention
 };

--- a/express/app/settings.js
+++ b/express/app/settings.js
@@ -27,6 +27,9 @@ const database = {
 const secret = process.env.BASSET_SECRET;
 const env = process.env.NODE_ENV;
 
+const enforceSnapshotLimit = process.env.ENFORCE_SNAPSHOT_LIMIT || false;
+const enforceSnapshotRetention = process.env.ENFORCE_SNAPSHOT_RENTETION || false;
+
 const cors = {
   origin: process.env.BASSET_ORIGIN,
   credentials: true,
@@ -123,4 +126,6 @@ module.exports = {
   awsBatch,
   session,
   saml,
+  enforceSnapshotLimit,
+  enforceSnapshotRetention
 };

--- a/express/app/settings.js
+++ b/express/app/settings.js
@@ -27,8 +27,8 @@ const database = {
 const secret = process.env.BASSET_SECRET;
 const env = process.env.NODE_ENV;
 
-const enforceSnapshotLimit = process.env.ENFORCE_SNAPSHOT_LIMIT || false;
-const enforceBuildRetention = process.env.ENFORCE_BUILD_RENTETION || false;
+const enforceSnapshotLimit = parseInt(process.env.ENFORCE_SNAPSHOT_LIMIT) === 1;
+const enforceBuildRetention = parseInt(process.env.ENFORCE_BUILD_RENTETION) === 1;
 
 const cors = {
   origin: process.env.BASSET_ORIGIN,

--- a/express/app/tasks/builds.js
+++ b/express/app/tasks/builds.js
@@ -3,7 +3,8 @@ const Build = require('../models/Build');
 const buildTimeout = 20 * 60 * 1000; // 20 minutes
 
 const checkBuild = async (build) => {
-  let lastUpdated = new Date();
+  let lastUpdated = build.updatedAt;
+  const now = new Date();
   const lastSnapshot = await build
     .$relatedQuery('snapshots')
     .orderBy('updatedAt', 'desc')
@@ -13,7 +14,7 @@ const checkBuild = async (build) => {
     lastUpdated = lastSnapshot.updatedAt;
   }
 
-  const timeDelta = lastUpdated - build.updatedAt;
+  const timeDelta = now - lastUpdated;
   if (timeDelta > buildTimeout) {
     console.error(
       `[checkBuilds] Build (id: ${build.id}) has timed out. There were${

--- a/express/app/tasks/checkBuilds.js
+++ b/express/app/tasks/checkBuilds.js
@@ -1,10 +1,7 @@
-const db = require('../db');
 const Build = require('../models/Build');
 const { checkBuild } = require('./builds');
 
-const knex = db.configure();
-
-const cronTasks = async () => {
+const run = async () => {
   console.log('[checkBuilds] checking for timed out builds');
   const builds = await Build
     .query()
@@ -18,8 +15,4 @@ const cronTasks = async () => {
   await destroy();
 };
 
-const destroy = async () => {
-  await knex.destroy();
-};
-
-cronTasks();
+module.exports = run;

--- a/express/app/tasks/checkBuilds.js
+++ b/express/app/tasks/checkBuilds.js
@@ -12,7 +12,6 @@ const run = async () => {
     await checkBuild(build);
   }
   console.log('[checkBuilds] complete');
-  await destroy();
 };
 
 module.exports = run;

--- a/express/app/tasks/checkBuilds.js
+++ b/express/app/tasks/checkBuilds.js
@@ -3,10 +3,12 @@ const { checkBuild } = require('./builds');
 
 const run = async () => {
   console.log('[checkBuilds] checking for timed out builds');
-  const builds = await Build
-    .query()
+  const builds = await Build.query()
     .whereNull('completedAt')
-    .orWhereNot('error', true);
+    .where(builder => {
+      builder.where('error', false)
+        .orWhereNull('error');
+    });
 
   for await (const build of builds) {
     await checkBuild(build);

--- a/express/app/tasks/cron.js
+++ b/express/app/tasks/cron.js
@@ -1,4 +1,4 @@
-const db = require('../../db');
+const db = require('../db');
 const deleteAssets = require('./deleteAssets');
 const checkBuilds = require('./checkBuilds');
 

--- a/express/app/tasks/cron.js
+++ b/express/app/tasks/cron.js
@@ -1,0 +1,34 @@
+const db = require('../../db');
+const deleteAssets = require('./deleteAssets');
+const checkBuilds = require('./checkBuilds');
+
+db.configure();
+
+const DAILY = "daily";
+const EVERY_FIVE_MINUTES = 'every-5-minutes';
+
+const cronTasks = {
+ [DAILY]: [
+    deleteAssets,
+  ],
+  [EVERY_FIVE_MINUTES]: [
+    checkBuilds,
+  ]
+};
+
+const runTasks = (tasks) => Promise.all(tasks.map(task => task.call()));
+
+async function handleTask() {
+  const schedule = process.argv.slice(2);
+  const tasks = cronTasks[schedule];
+  if (tasks) {
+    await runTasks(tasks);
+  }
+  await destroy();
+}
+
+handleTask();
+
+const destroy = async () => {
+  await knex.destroy();
+};

--- a/express/app/tasks/cron.js
+++ b/express/app/tasks/cron.js
@@ -2,7 +2,7 @@ const db = require('../db');
 const deleteAssets = require('./deleteAssets');
 const checkBuilds = require('./checkBuilds');
 
-db.configure();
+const knex = db.configure();
 
 const DAILY = "daily";
 const EVERY_FIVE_MINUTES = 'every-5-minutes';
@@ -21,14 +21,16 @@ const runTasks = (tasks) => Promise.all(tasks.map(task => task.call()));
 async function handleTask() {
   const schedule = process.argv.slice(2);
   const tasks = cronTasks[schedule];
+  console.log(`[cron] running ${tasks.length} tasks for ${schedule}`);
   if (tasks) {
     await runTasks(tasks);
   }
+  console.log(`[cron] jobs done`);
   await destroy();
 }
 
 handleTask();
 
-const destroy = async () => {
+async function destroy() {
   await knex.destroy();
-};
+}

--- a/express/app/tasks/deleteAssets.js
+++ b/express/app/tasks/deleteAssets.js
@@ -1,0 +1,78 @@
+const url = require('url');
+const { ref } = require('objection');
+
+const Organization = require('../models/Organization');
+const Build = require('../models/Build');
+const BuildAsset = require('../models/BuildAsset');
+const Asset = require('../models/Asset');
+const settings = require('../settings');
+const s3 = require('../utils/s3config');
+
+const deleteFiles = async (bucket, keysToDelete) => {
+  let keys = keysToDelete.slice(0, 1000);
+  let count = 1000;
+  while (keys.length > 0) {
+    const params = {
+      Bucket: bucket,
+      Delete: {
+        Objects: keys,
+      },
+    };
+    await s3.deleteObjects(params).promise();
+    keys = keysToDelete.slice(count, count += 1000)
+  }
+};
+
+const getKeys = locations => locations.map(location => url
+  .parse(location)
+  .path.split('/')
+  .slice(2)
+  .join('/'),
+);
+
+const run = async () => {
+  console.log('[removeSnapshotData] clearing old snapshot data');
+
+  const organizations = await Organization.query().where('enforceBuildRetention', true);
+  for await (const organization of organizations.values()) {
+    const retentionLimit = new Date();
+    retentionLimit.setDate(retentionLimit.getDate() - organization.buildRetentionPeriod);
+
+    // for now we remove old snapshot source data and assets from storage
+    const snapshots = await Build
+      .query()
+      .select('snapshots.sourceLocation')
+      .joinRelation('snapshots')
+      .where('build.organizationId', organization.id)
+      .where('build.createdAt', '<', retentionLimit);
+
+    let keys = getKeys(snapshots.map(snapshot => snapshot.sourceLocation));
+
+    const assets = await Asset
+      .query()
+      .distinct('location')
+      .innerJoinRelation('buildAssets')
+      .where('asset.organizationId', organization.id)
+      .where('asset.createdAt', '<', retentionLimit)
+      .whereRaw(
+        '? < ?',
+        [
+          BuildAsset.raw(
+            BuildAsset.query().max('createdAt').where('buildAsset.assetId', ref('asset.id')),
+          ).wrap('(', ')'),
+          retentionLimit,
+        ],
+      );
+
+    keys = [
+      ...keys,
+      ...getKeys(assets.map(asset => asset.location)),
+    ];
+    console.log(`[removeSnapshotData] found ${keys.length} snapshots and assets to remove`)
+    await deleteFiles(settings.s3.assetsBucket, keys);
+  }
+  console.log('[removeSnapshotData] complete');
+  await destroy();
+};
+
+module.exports = run;

--- a/express/app/tasks/deleteAssets.js
+++ b/express/app/tasks/deleteAssets.js
@@ -72,7 +72,6 @@ const run = async () => {
     await deleteFiles(settings.s3.assetsBucket, keys);
   }
   console.log('[removeSnapshotData] complete');
-  await destroy();
 };
 
 module.exports = run;

--- a/express/app/utils/build.js
+++ b/express/app/utils/build.js
@@ -49,13 +49,14 @@ const checkBuild = async (req, res, next) => {
   if (!error) {
     build = await Build.query()
       .joinRelation('project')
-      .joinEager('organization')
+      .eager('[project, organization]')
       .where('project.key', token)
       .where('build.id', buildId)
       .first();
     if (!build) {
       error = 'Invalid build';
     } else if (await build.organization.snapshotLimitExceeded()) {
+      await build.notifySnapshotsExceeded();
       error = 'Monthly snapshot limit exceeded';
     }
   }

--- a/express/app/utils/build.js
+++ b/express/app/utils/build.js
@@ -25,6 +25,8 @@ const getProject = async req => {
     return false;
   }
   const project = await Project.query()
+    .joinRelation('organization')
+    .eager('organization')
     .where('key', token)
     .first();
 
@@ -36,6 +38,7 @@ const getProject = async req => {
 
 const checkBuild = async (req, res, next) => {
   let error = false;
+  let build;
   const token = getToken(req);
   const buildId = getBuildId(req);
   if (!buildId) {
@@ -46,6 +49,8 @@ const checkBuild = async (req, res, next) => {
   if (!error) {
     build = await Build.query()
       .joinRelation('project')
+      .joinRelation('organization')
+      .eager('organization')
       .eager('project')
       .where('project.key', token)
       .where('build.id', buildId)
@@ -53,6 +58,9 @@ const checkBuild = async (req, res, next) => {
 
     if (!build) {
       error = 'Invalid build';
+    }
+    if (await build.organization.snapshotLimitExceeded()) {
+      error = 'Monthly snapshot limit exceeded';
     }
   }
 

--- a/express/app/utils/build.js
+++ b/express/app/utils/build.js
@@ -49,17 +49,13 @@ const checkBuild = async (req, res, next) => {
   if (!error) {
     build = await Build.query()
       .joinRelation('project')
-      .joinRelation('organization')
-      .eager('organization')
-      .eager('project')
+      .joinEager('organization')
       .where('project.key', token)
       .where('build.id', buildId)
       .first();
-
     if (!build) {
       error = 'Invalid build';
-    }
-    if (await build.organization.snapshotLimitExceeded()) {
+    } else if (await build.organization.snapshotLimitExceeded()) {
       error = 'Monthly snapshot limit exceeded';
     }
   }

--- a/express/app/utils/upload.js
+++ b/express/app/utils/upload.js
@@ -112,16 +112,12 @@ const uploadAsset = multer({
 });
 
 const deleteFile = async (bucket, key) => {
-  try {
-    await s3
-      .deleteObject({
-        Bucket: bucket,
-        Key: key,
-      })
-      .promise();
-  } catch (error) {
-    throw error;
-  }
+  await s3
+    .deleteObject({
+      Bucket: bucket,
+      Key: key,
+    })
+    .promise();
 };
 
 const copySnapshotDiffToFlake = async (snapshotDiff, snapshot) => {
@@ -131,8 +127,8 @@ const copySnapshotDiffToFlake = async (snapshotDiff, snapshot) => {
   );
   const uuid = uuidv4();
   const key = `${snapshot.organizationId}/${snapshot.projectId}/flakes/${
-    snapshot.title
-  }/${snapshot.width}/${uuid}.png`;
+    snapshot.id
+  }/${uuid}.png`;
   await s3
     .copyObject({
       Bucket: settings.s3.screenshotBucket,

--- a/express/migrations/20191130162727_org_snapshot_limit.js
+++ b/express/migrations/20191130162727_org_snapshot_limit.js
@@ -2,8 +2,8 @@ exports.up = function (knex) {
   return knex.schema.table('organization', table => {
     table.integer('monthly_snapshot_limit').defaultTo(7500).notNullable();
     table.bool('enforce_snapshot_limit').defaultTo(false).notNullable();
-    table.integer('snapshot_retention_period').defaultTo(45).notNullable();
-    table.bool('enforce_snapshot_retention').defaultTo(false).notNullable();
+    table.integer('build_retention_period').defaultTo(60).notNullable();
+    table.bool('enforce_build_retention').defaultTo(false).notNullable();
   });
 };
 
@@ -11,7 +11,7 @@ exports.down = function (knex) {
   return knex.schema.table('organization', table => {
     table.dropColumn('monthly_snapshot_limit');
     table.dropColumn('enforce_snapshot_limit');
-    table.dropColumn('snapshot_retention_period');
-    table.dropColumn('enforce_snapshot_retention');
+    table.dropColumn('build_retention_period');
+    table.dropColumn('enforce_build_retention');
   })
 };

--- a/express/migrations/20191130162727_org_snapshot_limit.js
+++ b/express/migrations/20191130162727_org_snapshot_limit.js
@@ -1,0 +1,17 @@
+exports.up = function (knex) {
+  return knex.schema.table('organization', table => {
+    table.integer('monthly_snapshot_limit').defaultTo(7500).notNullable();
+    table.bool('enforce_snapshot_limit').defaultTo(false).notNullable();
+    table.integer('snapshot_retention_period').defaultTo(45).notNullable();
+    table.bool('enforce_snapshot_retention').defaultTo(false).notNullable();
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.table('organization', table => {
+    table.dropColumn('monthly_snapshot_limit');
+    table.dropColumn('enforce_snapshot_limit');
+    table.dropColumn('snapshot_retention_period');
+    table.dropColumn('enforce_snapshot_retention');
+  })
+};

--- a/express/tests/unit/tasks/builds.test.js
+++ b/express/tests/unit/tasks/builds.test.js
@@ -24,14 +24,15 @@ describe('build tasks', () => {
     expect(build.error).toBe(true);
   });
 
-  test('monitorBuildStats error when last snapshot is greater than 20 minutes from build updatedAt', async () => {
+  test('monitorBuildStats error when last snapshot is greater than 20 minutes from now', async () => {
     jest.useFakeTimers();
     let build = await createBuild('master', project);
-    await createSnapshot('test', build);
+    const snapshot = await createSnapshot('test', build);
     const date = new Date();
     date.setMinutes(date.getMinutes() - 21);
-    build.__proto__.$beforeUpdate = () => {};
-    await build.$query().update({
+    snapshot.__proto__.$beforeUpdate = () => {};
+
+    await snapshot.$query().update({
       updatedAt: date.toISOString(),
     });
 

--- a/express/tests/unit/utils/build.test.js
+++ b/express/tests/unit/utils/build.test.js
@@ -131,7 +131,7 @@ describe('build utils', () => {
         authorization: `Token ${project.key}`,
       },
     };
-    expect(await utils.getProject(req)).toEqual(project);
+    expect(await utils.getProject(req)).toEqual(expect.objectContaining(project));
     req.headers.authorization = '';
     expect(await utils.getProject(req)).toBe(false);
     req.headers.authorization = `Token 1234`;

--- a/express/tests/unit/utils/build.test.js
+++ b/express/tests/unit/utils/build.test.js
@@ -9,6 +9,10 @@ describe('build utils', () => {
   let project, build, organization;
   beforeAll(async () => {
     organization = await createOrganization('builder');
+    await organization.$query().update({
+      enforceSnapshotLimit: true,
+      monthlySnapshotLimit: 10000,
+    });
     project = await createProject('testr', organization.id);
     build = await createBuild('master', project);
   });
@@ -36,7 +40,22 @@ describe('build utils', () => {
       expect(res.status).toHaveBeenCalledWith(403);
       expect(res.json).toHaveBeenCalledWith({ error: 'Invalid build' });
     });
+    it('should error if the monthly snapshot limit has been exceeded', async () => {
+      const newOrg = await createOrganization('b');
+      await newOrg.$query().update({
+        enforceSnapshotLimit: true,
+        monthlySnapshotLimit: 0,
+      });
+      const newProject = await createProject('testr', newOrg.id);
+      const newBuild = await createBuild('master', newProject);
+      req.headers['x-build-id'] = null;
+      req.headers['x-build-id'] = newBuild.id;
+      req.headers['authorization'] =`Token ${newProject.key}`;
 
+      await utils.checkBuild(req, res, next);
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.json).toHaveBeenCalledWith({ error: 'Monthly snapshot limit exceeded' });
+    });
     it('should error if token is not included', async () => {
       req.headers.authorization = null;
       await utils.checkBuild(req, res, next);

--- a/infrastructure/kube/app/worker-job.yaml
+++ b/infrastructure/kube/app/worker-job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: basset-worker
+  name: basset-worker-5mins
 spec:
   schedule: "*/5 * * * *"
   jobTemplate:
@@ -12,7 +12,27 @@ spec:
             - name: basset-worker
               image: getbasset/basset-app:release-1.0.0-beta-7
               command: ["node"]
-              args: ["app/tasks/cronTasks.js"]
+              args: ["app/tasks/cron.js", "every-5-minutes"]
+              envFrom:
+                - configMapRef:
+                    name: basset-app-config
+          restartPolicy: OnFailure
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: basset-worker-daily
+spec:
+  schedule: "0 0 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: basset-worker
+              image: getbasset/basset-app:release-1.0.0-beta-7
+              command: ["node"]
+              args: ["app/tasks/cron.js", "daily"]
               envFrom:
                 - configMapRef:
                     name: basset-app-config

--- a/react/src/app/Home.jsx
+++ b/react/src/app/Home.jsx
@@ -11,7 +11,7 @@ export default class HomePage extends React.PureComponent {
       this.props.user.canCreateOrganizations;
     return (
       <React.Fragment>
-        {showNoOrganizations && (
+        {true && (
           <Box gap="large">
             <Text>You currently do not have any organizations setup</Text>
             <Text>

--- a/react/src/app/Home.jsx
+++ b/react/src/app/Home.jsx
@@ -11,7 +11,7 @@ export default class HomePage extends React.PureComponent {
       this.props.user.canCreateOrganizations;
     return (
       <React.Fragment>
-        {true && (
+        {showNoOrganizations && (
           <Box gap="large">
             <Text>You currently do not have any organizations setup</Text>
             <Text>

--- a/react/src/app/builds/components/Builds.jsx
+++ b/react/src/app/builds/components/Builds.jsx
@@ -29,7 +29,7 @@ export class Builds extends React.PureComponent {
       }).isRequired,
     ),
     currentBuild: PropTypes.shape({
-      id: PropTypes.string.siRequired,
+      id: PropTypes.string.isRequired,
     }),
     onChangeBuild: PropTypes.func.isRequired,
     onReload: PropTypes.func.isRequired,

--- a/react/src/app/builds/components/Builds.jsx
+++ b/react/src/app/builds/components/Builds.jsx
@@ -1,33 +1,28 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { Box, Text, Button } from 'grommet';
-import { Update } from 'grommet-icons';
+import { Box, Button, Text } from 'grommet';
+import { StatusWarning, Update } from 'grommet-icons';
 
 import {
   getBuilds,
+  getCurrentBuild,
+  getHasNextPage,
   getIsLoading,
   getIsLoadingMore,
-  getHasNextPage,
-  getCurrentBuild,
 } from '../../../redux/builds/selectors.js';
-import {
-  changeBuild,
-  loadMore,
-  setCurrentBuild,
-  getBuilds as reloadBuilds,
-} from '../../../redux/builds/actions.js';
+import { getCurrentOrganization } from '../../../redux/organizations/selectors.js';
 
+import { changeBuild, getBuilds as reloadBuilds, loadMore, setCurrentBuild } from '../../../redux/builds/actions.js';
 import LoadMoreButton from '../../../components/LoadMoreButton/LoadMoreButton.jsx';
-import Loader from '../../../components/Loader/Loader.jsx';
-import LoadingBox, {
-  Progress,
-} from '../../../components/LoadingBox/LoadingBox.jsx';
 
+import LoadingBox, { Progress } from '../../../components/LoadingBox/LoadingBox.jsx';
 import Build from './Build.jsx';
+import Link from '../../../components/Link/Link.jsx';
 
 export class Builds extends React.PureComponent {
   static propTypes = {
+    organization: PropTypes.object.isRequired,
     builds: PropTypes.arrayOf(
       PropTypes.shape({
         id: PropTypes.string.isRequired,
@@ -46,6 +41,11 @@ export class Builds extends React.PureComponent {
 
   get hasBuilds() {
     return this.props.builds.length > 0;
+  }
+
+  get snapshotsExceeded() {
+    const { organization } = this.props;
+    return organization.enforceSnapshotLimit && organization.currentSnapshotCount >= organization.monthlySnapshotLimit;
   }
 
   get currentBuildId() {
@@ -80,25 +80,32 @@ export class Builds extends React.PureComponent {
     }
     return (
       <Box fill direction="column" margin="none">
-        {this.hasBuilds && (
-          <React.Fragment>
-            <Button
-              alignSelf="end"
-              icon={<Update />}
-              onClick={this.props.onReload}
-              disabled={this.props.isLoading}
-            />
-            <Box>
-              {this.props.builds.map(build => (
-                <Build
-                  key={build.id}
-                  build={build}
-                  onChangeBuild={this.props.onChangeBuild}
-                  active={this.currentBuildId === build.id}
-                />
-              ))}
+        {this.snapshotsExceeded && (
+          <Box border={{color: 'status-warning', size: 'medium'}} round size="small" pad="medium" align="center">
+            <Box direction="row" align="center" gap="small">
+              <StatusWarning color="status-warning" />
+              <Text size="medium">You have reached the monthly limit for builds & snapshots.</Text>
             </Box>
-          </React.Fragment>
+            <Link href="/organizations" color="dark-2" label="Monthly limits" />
+          </Box>
+        )}
+        <Button
+          alignSelf="end"
+          icon={<Update />}
+          onClick={this.props.onReload}
+          disabled={this.props.isLoading}
+        />
+        {this.hasBuilds && (
+          <Box>
+            {this.props.builds.map(build => (
+              <Build
+                key={build.id}
+                build={build}
+                onChangeBuild={this.props.onChangeBuild}
+                active={this.currentBuildId === build.id}
+              />
+            ))}
+          </Box>
         )}
         {!this.hasBuilds && (
           <Box
@@ -131,6 +138,7 @@ const mapState = state => ({
   hasNextPage: getHasNextPage(state),
   builds: getBuilds(state),
   currentBuild: getCurrentBuild(state),
+  organization: getCurrentOrganization(state),
 });
 
 const mapAction = dispatch => ({

--- a/react/src/app/organizations/Organization.jsx
+++ b/react/src/app/organizations/Organization.jsx
@@ -12,7 +12,10 @@ class Organization extends React.PureComponent {
   static propTypes = {
     organization: PropTypes.object,
     user: PropTypes.object.isRequired,
-    error: PropTypes.string.isRequired,
+    error: PropTypes.shape({
+      loading: PropTypes.string.isRequired,
+      updating: PropTypes.string.isRequired,
+    }).isRequired,
     isUpdating: PropTypes.bool.isRequired,
     onSaveName: PropTypes.func.isRequired,
   };
@@ -21,11 +24,11 @@ class Organization extends React.PureComponent {
     organization: null,
   };
 
-  renderError = error => (
+  renderError = (type, error) => (
     <Notification
       type="error"
       error={error}
-      message={`There was an error trying to update this project`}
+      message={`There was an error trying to ${type} this organization`}
     />
   );
 
@@ -42,7 +45,8 @@ class Organization extends React.PureComponent {
         pad={{ bottom: 'medium' }}
         border={{ side: 'bottom' }}
       >
-        {this.props.error && this.renderError(this.props.error)}
+        {this.props.error.loading && this.renderError('retrieve', this.props.error.loading)}
+        {this.props.error.updating && this.renderError('update', this.props.error.updating)}
         <Box direction="row" justify="between" align="center">
           <Heading level={4}>Details</Heading>
           {canCreate && (
@@ -82,6 +86,32 @@ class Organization extends React.PureComponent {
           onSubmit={this.props.onSaveName}
           isUpdating={this.props.isUpdating}
         />
+        {this.props.organization.enforceSnapshotLimit && (
+          <React.Fragment>
+            <InlineField
+              title="Monthly snapshot limit"
+              value={this.props.organization.monthlySnapshotLimit}
+              canChange={false}
+            />
+            <InlineField
+              title="Current snapshot count"
+              value={this.props.organization.currentSnapshotCount}
+              canChange={false}
+            />
+            <InlineField
+              title="Snapshots remaining"
+              value={this.props.organization.monthlySnapshotLimit - this.props.organization.currentSnapshotCount}
+              canChange={false}
+            />
+          </React.Fragment>
+        )}
+        {this.props.organization.enforceSnapshotRetention && (
+          <InlineField
+            title="Snapshot data retention"
+            value={`${this.props.organization.snapshotRetentionPeriod} days`}
+            canChange={false}
+          />
+        )}
       </Box>
     );
   }

--- a/react/src/app/organizations/Organization.jsx
+++ b/react/src/app/organizations/Organization.jsx
@@ -105,10 +105,10 @@ class Organization extends React.PureComponent {
             />
           </React.Fragment>
         )}
-        {this.props.organization.enforceSnapshotRetention && (
+        {this.props.organization.enforceBuildRetention && (
           <InlineField
-            title="Snapshot data retention"
-            value={`${this.props.organization.snapshotRetentionPeriod} days`}
+            title="Builds and snapshot retention"
+            value={`${this.props.organization.buildRetentionPeriod} days`}
             canChange={false}
           />
         )}

--- a/react/src/app/organizations/route.jsx
+++ b/react/src/app/organizations/route.jsx
@@ -2,8 +2,10 @@ import React from 'react';
 
 import Organization from './controller.jsx';
 import Home from '../Home-controller.jsx';
+import { getOrganization } from '../../redux/organizations/actions';
 
 export default async (context, params, history, dispatch, getState) => {
+  await dispatch(getOrganization());
   return {
     title: `Basset • Organizations`,
     component: (

--- a/react/src/components/InlineField/InlineField.jsx
+++ b/react/src/components/InlineField/InlineField.jsx
@@ -24,7 +24,7 @@ const InlineField = React.memo(
       children = (
         <Form onSubmit={handleSubmit}>
           <Box gap="small" direction="row">
-            <Box width="medium" align="center">
+            <Box width="medium">
               <TextInput
                 data-test-id={`${testId}-input`}
                 value={newValue}
@@ -71,7 +71,7 @@ const InlineField = React.memo(
       );
     }
     return (
-      <Box direction="row" justify="between" align="center">
+      <Box direction="row" justify="between">
         <Text margin={{ vertical: 'small' }}>{title}</Text>
         {children}
       </Box>

--- a/react/src/components/InlineField/InlineField.jsx
+++ b/react/src/components/InlineField/InlineField.jsx
@@ -19,7 +19,7 @@ const InlineField = React.memo(
     };
     let children;
     if (!canChange) {
-      children = <Text>{value}</Text>;
+      children = <Text alignSelf="center">{value}</Text>;
     } else if (isEditing) {
       children = (
         <Form onSubmit={handleSubmit}>

--- a/react/src/components/InlineField/InlineField.jsx
+++ b/react/src/components/InlineField/InlineField.jsx
@@ -24,7 +24,7 @@ const InlineField = React.memo(
       children = (
         <Form onSubmit={handleSubmit}>
           <Box gap="small" direction="row">
-            <Box width="medium">
+            <Box width="medium" align="center">
               <TextInput
                 data-test-id={`${testId}-input`}
                 value={newValue}
@@ -71,7 +71,7 @@ const InlineField = React.memo(
       );
     }
     return (
-      <Box direction="row" justify="between">
+      <Box direction="row" justify="between" align="center">
         <Text margin={{ vertical: 'small' }}>{title}</Text>
         {children}
       </Box>
@@ -83,7 +83,7 @@ InlineField.propTypes = {
   canChange: PropTypes.bool.isRequired,
   isUpdating: PropTypes.bool,
   title: PropTypes.string.isRequired,
-  value: PropTypes.string,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   onSubmit: PropTypes.func,
 };
 

--- a/react/src/graphql/query/getOrganization.js
+++ b/react/src/graphql/query/getOrganization.js
@@ -1,0 +1,16 @@
+import gql from 'graphql-tag';
+
+export default gql`
+  query organization($id: ID!) {
+    organization(id: $id) {
+      id
+      name
+      admin
+      monthlySnapshotLimit
+      enforceSnapshotLimit
+      currentSnapshotCount
+      snapshotRetentionPeriod
+      enforceSnapshotRetention
+    }
+  }
+`;

--- a/react/src/graphql/query/getOrganization.js
+++ b/react/src/graphql/query/getOrganization.js
@@ -9,8 +9,8 @@ export default gql`
       monthlySnapshotLimit
       enforceSnapshotLimit
       currentSnapshotCount
-      snapshotRetentionPeriod
-      enforceSnapshotRetention
+      buildRetentionPeriod
+      enforceBuildRetention
     }
   }
 `;

--- a/react/src/graphql/query/getUser.js
+++ b/react/src/graphql/query/getUser.js
@@ -19,8 +19,8 @@ export default gql`
             monthlySnapshotLimit
             enforceSnapshotLimit
             currentSnapshotCount
-            snapshotRetentionPeriod
-            enforceSnapshotRetention
+            buildRetentionPeriod
+            enforceBuildRetention
           }
         }
       }

--- a/react/src/graphql/query/getUser.js
+++ b/react/src/graphql/query/getUser.js
@@ -16,6 +16,11 @@ export default gql`
             id
             name
             admin
+            monthlySnapshotLimit
+            enforceSnapshotLimit
+            currentSnapshotCount
+            snapshotRetentionPeriod
+            enforceSnapshotRetention
           }
         }
       }

--- a/react/src/redux/organizations/actions.js
+++ b/react/src/redux/organizations/actions.js
@@ -1,5 +1,6 @@
 import ApolloClient from '../../graphql/client.js';
 import editOrganizationMutation from '../../graphql/mutate/editOrganization.js';
+import getOrganizationQuery from '../../graphql/query/getOrganization.js';
 
 import { getProjects } from '../projects/actions.js';
 import { getCurrentOrganization } from './selectors.js';
@@ -44,6 +45,24 @@ export const changeOrganization = ({ id }) => async (dispatch, getState) => {
     await dispatch(getProjects());
     goHome();
     dispatch(doneLoading());
+  }
+};
+
+export const getOrganization = () => async (dispatch, getState) => {
+  const { currentOrganizationId } = getState().organizations;
+  dispatch(isLoading());
+  try {
+    const { data } = await ApolloClient.query({
+      query: getOrganizationQuery,
+      variables: {
+        id: currentOrganizationId,
+      }
+    });
+    dispatch(updateOrganization(data.organization));
+    dispatch(doneLoading());
+  } catch (error) {
+    dispatch(doneLoading());
+    dispatch(setError(error));
   }
 };
 

--- a/react/src/redux/organizations/actions.js
+++ b/react/src/redux/organizations/actions.js
@@ -21,8 +21,9 @@ export const updateOrganization = organization => ({
   organization,
 });
 
-export const setError = error => ({
+export const setError = (errorType, error) => ({
   type: actionTypes.setError,
+  errorType,
   error,
 });
 
@@ -62,7 +63,7 @@ export const getOrganization = () => async (dispatch, getState) => {
     dispatch(doneLoading());
   } catch (error) {
     dispatch(doneLoading());
-    dispatch(setError(error));
+    dispatch(setError('loading', error));
   }
 };
 
@@ -94,7 +95,7 @@ export const saveOrganization = ({ name }) => async (dispatch, getState) => {
     }
     dispatch(doneUpdating());
   } catch (error) {
-    dispatch(setError(error));
+    dispatch(setError('updating', error));
     dispatch(doneUpdating());
   }
 };

--- a/react/src/redux/organizations/actions.spec.js
+++ b/react/src/redux/organizations/actions.spec.js
@@ -25,9 +25,9 @@ beforeEach(() => {
 });
 
 test('setError', () => {
-  store.dispatch(actions.setError('oops'));
+  store.dispatch(actions.setError('updating', 'oops'));
   const { organizations } = store.getState();
-  expect(organizations.error).toBe('oops');
+  expect(organizations.error.updating).toBe('oops');
 });
 
 test('isLoading', () => {
@@ -142,6 +142,6 @@ test('saveOrganization', async () => {
   await save;
   state = store.getState().organizations;
   expect(state.isUpdating).toBe(false);
-  expect(state.error).toBe('');
+  expect(state.error.updating).toBe('');
   expect(state.organizations[0].name).toBe('Basset updated');
 });

--- a/react/src/redux/organizations/reducer.js
+++ b/react/src/redux/organizations/reducer.js
@@ -31,11 +31,11 @@ const handler = {
     ...state,
     isUpdating: false,
   }),
-  [actionTypes.setError]: (state, { type, error }) => ({
+  [actionTypes.setError]: (state, { errorType, error }) => ({
     ...state,
     error: {
       ...state.error,
-      [type]: error,
+      [errorType]: error,
     }
   }),
   [actionTypes.receiveOrganizations]: (state, { organizations }) => ({

--- a/react/src/redux/organizations/reducer.js
+++ b/react/src/redux/organizations/reducer.js
@@ -5,7 +5,10 @@ import * as actionTypes from './action-types';
 const initialState = {
   isLoading: false,
   isUpdating: false,
-  error: '',
+  error: {
+    loading: '',
+    updating: '',
+  },
   organizations: [],
   total: null,
   currentOrganizationId: null,
@@ -28,9 +31,12 @@ const handler = {
     ...state,
     isUpdating: false,
   }),
-  [actionTypes.setError]: (state, { error }) => ({
+  [actionTypes.setError]: (state, { type, error }) => ({
     ...state,
-    error,
+    error: {
+      ...state.error,
+      [type]: error,
+    }
   }),
   [actionTypes.receiveOrganizations]: (state, { organizations }) => ({
     ...state,


### PR DESCRIPTION
This PR adds the ability to limit the number of snaphsots per month and add a data retention limit for snapshot source and assets. Each limit is configured on an organization by organization basis and can be turned off.

After the monthly snapshot limit has been reached additional snapshots cannot be created.
After the build retention days - snapshot source (HTML files) and assets will be deleted from block storage.