### PR TITLE
fix(assets): properly set url for private assets

### DIFF
--- a/express/app/utils/stream-transformer.js
+++ b/express/app/utils/stream-transformer.js
@@ -12,14 +12,14 @@ const replaceUrl = (assets, str, assetsUrl, relativePath) => {
   const replacer = (match, p1, offset, str) => {
     const asset = findAsset(assets, p1, relativePath);
     if (asset) {
-      let url = `url(${assetsUrl}/${getAssetsPath(
+      let url = `${assetsUrl}/${getAssetsPath(
         asset.relativePath,
         asset.sha,
-      )})`;
+      )}`;
       if (settings.s3.privateAssets) {
-        url = `${url}?token=${settings.token})`;
+        url = `${url}?token=${settings.token}`;
       }
-      return url;
+      return `url(${url})`;
     }
     return `url(${p1})`;
   };
@@ -51,7 +51,7 @@ const transformHTML = (assets, assetsUrl, relativePath) => {
           asset.sha,
         )}`;
         if (settings.s3.privateAssets) {
-          url = `${url}?token=${settings.token})`;
+          url = `${url}?token=${settings.token}`;
         }
         element.setAttribute(name, url);
       }


### PR DESCRIPTION
this PR fixes the attributes for HTML and css urls for private assets. Currently html attributes are appending a `)` and then css assets will append the token outside of the url so they wont work.