### PR TITLE
fix(kubernetes): add /dev/shm mount to stop chrome from crashing

### DIFF
--- a/infrastructure/kube/diff/deployment.yaml
+++ b/infrastructure/kube/diff/deployment.yaml
@@ -12,6 +12,10 @@ spec:
       labels:
         app: basset-diff
     spec:
+      volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
       containers:
         - name: basset-diff
           image: getbasset/basset-diff:release-1.0.0-beta-15
@@ -19,3 +23,6 @@ spec:
           envFrom:
             - configMapRef:
                 name: basset-diff-config
+          volumeMounts:
+            - mountPath: /dev/shm
+              name: dshm


### PR DESCRIPTION
- This issue has popped up before, when rendering snapshots Chrome (not sure about Firefox) will crash if /dev/shm does not have enough memory. When changing the window size and generating a screenshot chrome often crashes if the window height is large. 
- Unfortunately there isn't a way to increase shm size like you can do in docker. But it seems mounting an empty directory works for Kubernetes.