### PR TITLE
use Unknown for previous users who have been removed after approving a snapshot

### DIFF
--- a/react/src/app/snapshots/components/SnapshotHeader.jsx
+++ b/react/src/app/snapshots/components/SnapshotHeader.jsx
@@ -134,7 +134,7 @@ const SnapshotHeader = React.memo(
         return null;
       }
       if (snapshot.approved) {
-        const approvedBy = snapshot.approvedBy.user.name;
+        const approvedBy = snapshot.approvedBy ? snapshot.approvedBy.user.name : 'Unknown';
         const approvedOn = moment(parseInt(snapshot.approvedOn)).format(
           'YYYY-MM-DD hh:mm a',
         );


### PR DESCRIPTION
This PR resolves an issue when removing a user who has previously approved Snapshots. Currently a error is returned since `approvedBy` is null. When a user has been removed instead show `Unknown`.