### PR TITLE
(feat): add IE and Edge

### DIFF
--- a/diff/Dockerfile
+++ b/diff/Dockerfile
@@ -5,7 +5,7 @@ RUN groupadd --gid 1000 python \
 
 WORKDIR /basset/
 
-RUN apt-get update && apt-get install -y unzip wget python3 python3-pip ttf-dejavu
+RUN apt-get update && apt-get install -y unzip wget python3 python3-pip ttf-dejavu fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf
 # libglib2 required for opencv
 # RUN apt-get update && apt-get -y install unzip wget; apt-get clean
 

--- a/diff/render/render.py
+++ b/diff/render/render.py
@@ -33,8 +33,12 @@ class Render(object):
         self.is_open = True
         if browser == 'firefox':
             self.driver = webdriver.Firefox(service_log_path='/tmp/firefox.log', options=self.firefox_options)
-        else:
+        if browser == 'chrome':
             self.driver = webdriver.Chrome(service_log_path='/tmp/chrome.log', options=self.chrome_options)
+        if browser == 'ie':
+            self.driver = webdriver.Ie()
+        if browser == 'edge':
+            self.driver = webdriver.Edge()
 
     def close_browser(self):
         self.is_open = False
@@ -47,13 +51,13 @@ class Render(object):
                 self.driver.execute_script(
                     """
                     let height = 0;
-                    document.querySelectorAll('*').forEach(e => {
+                    Array.prototype.slice.call(document.querySelectorAll('*')).forEach(function (e) {
                         let rect = e.getClientRects();
                         if (rect.length > 0) {
                             const style = window.getComputedStyle(e);
                             let marginTop = parseInt(style.marginTop || 0);
                             let marginBottom = parseInt(style.marginBottom || 0);
-                            let calcHeight = rect[0].y + rect[0].height + marginTop + marginBottom;
+                            let calcHeight = rect[0].top + rect[0].height + marginTop + marginBottom;
                             if (calcHeight > height) {
                                 height = calcHeight;
                             }
@@ -75,7 +79,7 @@ class Render(object):
                 let hideSelectors = arguments[0];
                 let hideStyle = document.createElement('style');
                 hideStyle.innerText = hideSelectors + ' { visibility: hidden };';
-                document.body.prepend(hideStyle);
+                document.body.insertBefore(hideStyle, document.body.childNodes[0]);
                 return hideStyle.innerText;
                 """,
                 selectors
@@ -93,7 +97,7 @@ class Render(object):
                 """
                 let animationStyle = document.createElement('style');
                 animationStyle.innerText = "* {-o-transition-property: none !important;-moz-transition-property: none !important;-ms-transition-property: none !important;-webkit-transition-property: none !important;transition-property: none !important;;-webkit-animation: none !important;-moz-animation: none !important;-o-animation: none !important;-ms-animation: none !important;animation: none !important;}"
-                document.body.prepend(animationStyle);
+                document.body.insertBefore(animationStyle, document.body.childNodes[0]);
                 """
             )
         except JavascriptException as ex:
@@ -125,6 +129,10 @@ class Render(object):
 
         if self.browser == 'firefox':
             height += 84
+        if self.browser == 'ie':
+            height += 86
+        if self.browser == 'edge':
+            height += 134
         print('setting window to height {}'.format(height))
         self.driver.set_window_size(width, height)
 

--- a/express/app/models/Project.js
+++ b/express/app/models/Project.js
@@ -3,6 +3,7 @@ const { Model } = require('objection');
 const BaseModel = require('./BaseModel');
 const Asset = require('./Asset');
 const { getSCM } = require('../integrations/scm');
+const { allowableBrowsers } = require('../settings');
 
 class Project extends BaseModel {
   $beforeInsert(queryContext) {
@@ -10,7 +11,7 @@ class Project extends BaseModel {
     return super.$beforeInsert(queryContext);
   }
   static get allowedBrowsers() {
-    return ['firefox', 'chrome'];
+    return Object.entries(allowableBrowsers).filter(([key, value]) => value === true).map(([key]) => key);
   }
 
   static get tableName() {

--- a/express/app/settings.js
+++ b/express/app/settings.js
@@ -115,6 +115,13 @@ const header = {
   scripts: [],
 };
 
+const allowableBrowsers = {
+  firefox: true,
+  chrome: true,
+  ie: parseInt(process.env.ENABLE_IE) === 1,
+  edge: parseInt(process.env.ENABLE_EDGE) === 1,
+};
+
 module.exports = {
   mail,
   database,
@@ -133,4 +140,5 @@ module.exports = {
   enforceSnapshotLimit,
   enforceBuildRetention,
   header,
+  allowableBrowsers,
 };

--- a/express/views/index.ejs
+++ b/express/views/index.ejs
@@ -32,6 +32,7 @@
         private: <%= settings.site.private %>,
         saml: <%= settings.saml.enabled %>,
         site: '<%= settings.site.url %>',
+        allowableBrowsers: '<%= settings.allowableBrowsers %>',
       }
     </script>
     <% if (settings.env === 'production') { %>

--- a/react/src/app/projects/single/Project.jsx
+++ b/react/src/app/projects/single/Project.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box, Text, Tabs, Tab, Heading, CheckBox } from 'grommet';
-import { UserAdmin, Firefox, Chrome } from 'grommet-icons';
+import { UserAdmin, Firefox, Chrome, Edge, InternetExplorer } from 'grommet-icons';
 import SyntaxHighlighter from 'react-syntax-highlighter';
 import { docco } from 'react-syntax-highlighter/dist/cjs/styles/hljs';
 
@@ -207,6 +207,50 @@ export class Project extends React.PureComponent {
                     toggle
                   />
                 </Box>
+                {__BASSET__.allowableBrowsers.ie && (
+                  <Box
+                    margin={{ vertical: 'small' }}
+                    direction="row"
+                    justify="between"
+                    align="center"
+                  >
+                    <Box direction="row" align="center" gap="small">
+                      <InternetExplorer color="plain" /> Internet Explorer
+                    </Box>
+                    <CheckBox
+                      data-test-id="toggle-ie"
+                      checked={this.hasBrowser('ie')}
+                      onChange={this.handleToggleBrowser('ie')}
+                      disabled={
+                        this.props.isUpdating || !this.props.organization.admin
+                      }
+                      reverse
+                      toggle
+                    />
+                  </Box>
+                )}
+                {__BASSET__.allowableBrowsers.edge && (
+                  <Box
+                    margin={{ vertical: 'small' }}
+                    direction="row"
+                    justify="between"
+                    align="center"
+                  >
+                    <Box direction="row" align="center" gap="small">
+                      <Edge color="plain" /> Edge
+                    </Box>
+                    <CheckBox
+                      data-test-id="toggle-edge"
+                      checked={this.hasBrowser('edge')}
+                      onChange={this.handleToggleBrowser('edge')}
+                      disabled={
+                        this.props.isUpdating || !this.props.organization.admin
+                      }
+                      reverse
+                      toggle
+                    />
+                  </Box>
+                )}
               </Box>
               <Integration />
             </Box>

--- a/react/src/app/projects/single/controller.spec.jsx
+++ b/react/src/app/projects/single/controller.spec.jsx
@@ -31,6 +31,12 @@ describe('<Project />', () => {
         gitlab: false,
         bitbucket: false,
       },
+      allowableBrowsers: {
+        chrome: true,
+        firefox: true,
+        ie: false,
+        edge: false,
+      }
     };
     projectActions.saveProject = jest.fn(() => (dispatch, getState) => {});
     store.dispatch(

--- a/react/src/app/snapshots/components/SnapshotHeader.jsx
+++ b/react/src/app/snapshots/components/SnapshotHeader.jsx
@@ -21,6 +21,8 @@ import {
   View,
   Next,
   Previous,
+  Edge,
+  InternetExplorer,
 } from 'grommet-icons';
 
 import Tooltip from '../../../components/Tooltip/Tooltip.jsx';
@@ -41,6 +43,20 @@ const getBrowserType = browser => {
     return (
       <Box title="Firefox">
         <Firefox color="plain" />
+      </Box>
+    );
+  }
+  if (browser === 'edge') {
+    return (
+      <Box title="Edge">
+        <Edge color="plain" />
+      </Box>
+    );
+  }
+  if (browser === 'ie') {
+    return (
+      <Box title="Internet Explorer">
+        <InternetExplorer color="plain" />
       </Box>
     );
   }


### PR DESCRIPTION
This PR adds browser support for IE and Edge. Currently to make this work you will require either a virtual machine or physical machine running windows running basset diff.

Currently there is only 1 queue for rendering and diffing snapshots. Which makes it very difficult to run a linux and windows vm should you want to separate snapshot rendering by browser. The resolution to this issue will be within another PR.