### PR TITLE
chore: use separate queues by browser for rabbitmq

### DIFF
--- a/express/app/settings.js
+++ b/express/app/settings.js
@@ -80,10 +80,17 @@ const awsBatch = {
   JobDefinition: process.env.AWS_BATCH_JOB_DEFINITION,
   jobQueue: process.env.AWS_BATCH_JOB_QUEUE,
 };
+
+const defaultBuildQueue = process.env.AMQP_BUILD_QUEUE;
 const amqp = {
   use: parseInt(process.env.USE_SQS) !== 1,
   host: process.env.AMQP_HOST,
-  buildQueue: process.env.AMQP_BUILD_QUEUE,
+  buildQueue: {
+    firefox: process.env.AMQP_FIREFOX_BUILD_QUEUE || defaultBuildQueue,
+    chrome: process.env.AMQP_CHROME_BUILD_QUEUE || defaultBuildQueue,
+    ie: process.env.AMQP_IE_BUILD_QUEUE || defaultBuildQueue,
+    edge: process.env.AMQP_EDGE_BUILD_QUEUE || defaultBuildQueue,
+  },
   taskQueue: process.env.AMQP_TASK_QUEUE,
 };
 


### PR DESCRIPTION
This PR allows multiple queues to be used for each browser.

The environment variable `AMQP_BUILD_QUEUE` variable is used as a fall back for existing configs.

Each queue is mapped by name so we're not calling assertQueue on the same queue.